### PR TITLE
fix: pause/resume/interrupt when num_actors>1 in DeployedGraph

### DIFF
--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -59,6 +59,21 @@ class MultiplexNodeWrapper:
     def load(self, node_dir):
         pass  # Silently ignore, multiplexed nodes are never saved
 
+    def pause(self):
+        """Pause all wrapped NodeWrapper actors."""
+        futures = [n.pause.remote() for n in self.wrapped_node_list]
+        ray.get(futures)
+
+    def resume(self):
+        """Resume all wrapped NodeWrapper actors."""
+        futures = [n.resume.remote() for n in self.wrapped_node_list]
+        ray.get(futures)
+
+    def interrupt(self):
+        """Interrupt all wrapped NodeWrapper actors."""
+        futures = [n.interrupt.remote() for n in self.wrapped_node_list]
+        ray.get(futures)
+
 
 @ray.remote
 class NodeWrapper:


### PR DESCRIPTION
### What & Why
When a node is multiplexed (num_actors > 1), pause/resume/interrupt only
affected a single wrapped actor. This PR applies the calls to all actors
in `wrapped_node_list`.

### Changes
- Add `pause()`, `resume()`, `interrupt()` in `DeployedGraph`.
- Broadcast calls to every `NodeWrapper` via Ray and wait for futures.

### How to Reproduce (before)
- Launch with num_actors > 1
- Call pause/resume/interrupt → only one actor reacts

### Behavior After
- All actors pause/resume/interrupt consistently.

### Tests / Validation
- Manual: launched with num_actors=8; verified all 8 actors respond.

### Backwards Compatibility / Risk
- No API change; just fixes multiplexed behavior.
- Ray futures are awaited; no change in single-actor behavior.
