### PR TITLE
Add MkDocs Material documentation with API autodocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Falcon - Distributed Dynamic Simulation-Based Inference
 
+[![Documentation](https://img.shields.io/badge/docs-cweniger.github.io%2Ffalcon-blue)](https://cweniger.github.io/falcon/)
+
 *Falcon* is a Python framework for **simulation-based inference (SBI)** that enables adaptive learning of complex conditional distributions. Built on top of PyTorch, Ray, and sbi, *Falcon* provides a declarative approach to building probabilistic models with automatic parallelization and experiment tracking.
 
 ## Key Features
@@ -320,7 +322,11 @@ buffer:
 
 ## Documentation
 
-- [SNPE_A Estimator](docs/estimators/SNPE_A.md) - Detailed configuration reference
+Full documentation is available at **[cweniger.github.io/falcon](https://cweniger.github.io/falcon/)**
+
+- [Getting Started](https://cweniger.github.io/falcon/getting-started/)
+- [Configuration Reference](https://cweniger.github.io/falcon/configuration/)
+- [API Reference](https://cweniger.github.io/falcon/api/)
 
 ## Troubleshooting
 

--- a/docs/api/base-estimator.md
+++ b/docs/api/base-estimator.md
@@ -1,0 +1,29 @@
+# BaseEstimator
+
+The abstract base class defining the estimator interface.
+
+## Overview
+
+All estimators in Falcon must implement this interface. The base class defines
+methods for:
+
+- Training (`train`)
+- Sampling (`sample_prior`, `sample_posterior`, `sample_proposal`)
+- Persistence (`save`, `load`)
+- Control flow (`pause`, `resume`, `interrupt`)
+
+## Class Reference
+
+::: falcon.core.base_estimator.BaseEstimator
+    options:
+      show_source: true
+      members:
+        - train
+        - sample_prior
+        - sample_posterior
+        - sample_proposal
+        - save
+        - load
+        - pause
+        - resume
+        - interrupt

--- a/docs/api/deployed-graph.md
+++ b/docs/api/deployed-graph.md
@@ -1,0 +1,17 @@
+# DeployedGraph
+
+The `DeployedGraph` class orchestrates distributed execution of Falcon graphs using Ray.
+
+## Overview
+
+`DeployedGraph` wraps a `Graph` and handles:
+
+- Ray actor initialization for each node
+- Distributed sample generation and training
+- Coordination between nodes during inference
+
+## Class Reference
+
+::: falcon.core.deployed_graph.DeployedGraph
+    options:
+      show_source: true

--- a/docs/api/flow.md
+++ b/docs/api/flow.md
@@ -1,0 +1,25 @@
+# Flow
+
+Normalizing flow networks for density estimation.
+
+## Overview
+
+The `Flow` class wraps various normalizing flow architectures for use in
+posterior estimation. It supports multiple flow types from different libraries.
+
+## Supported Flow Types
+
+| Type | Library | Description |
+|------|---------|-------------|
+| `nsf` | sbi/nflows | Neural Spline Flow |
+| `maf` | sbi/nflows | Masked Autoregressive Flow |
+| `zuko_nice` | Zuko | NICE architecture |
+| `zuko_naf` | Zuko | Neural Autoregressive Flow |
+| `zuko_nsf` | Zuko | Neural Spline Flow (Zuko) |
+| `zuko_maf` | Zuko | Masked Autoregressive Flow (Zuko) |
+
+## Class Reference
+
+::: falcon.contrib.flow.Flow
+    options:
+      show_source: true

--- a/docs/api/graph.md
+++ b/docs/api/graph.md
@@ -1,0 +1,30 @@
+# Graph
+
+The graph module provides the core data structures for defining probabilistic models.
+
+## Overview
+
+A Falcon graph consists of `Node` objects connected by parent-child relationships.
+The `Graph` class manages these relationships and handles topological sorting for
+correct execution order.
+
+## Classes
+
+::: falcon.core.graph.Node
+    options:
+      members:
+        - __init__
+
+::: falcon.core.graph.Graph
+    options:
+      members:
+        - __init__
+        - get_parents
+        - get_evidence
+        - get_simulator_cls
+
+## Functions
+
+::: falcon.core.graph.CompositeNode
+
+::: falcon.core.graph.create_graph_from_config

--- a/docs/api/hypercube-prior.md
+++ b/docs/api/hypercube-prior.md
@@ -1,0 +1,64 @@
+# HypercubeMappingPrior
+
+Flexible prior distributions with hypercube mapping.
+
+## Overview
+
+`HypercubeMappingPrior` maps between a hypercube domain and various target
+distributions. This enables uniform treatment of different prior types during
+training while preserving the original distribution semantics.
+
+## Supported Distributions
+
+| Type | Parameters | Description |
+|------|------------|-------------|
+| `uniform` | `low`, `high` | Uniform distribution |
+| `normal` | `mean`, `std` | Gaussian distribution |
+| `cosine` | `low`, `high` | Distribution with pdf proportional to sin(angle) |
+| `sine` | `low`, `high` | Inverse sine mapping |
+| `uvol` | `low`, `high` | Uniform-in-volume |
+| `triangular` | `a`, `c`, `b` | Triangular distribution (min, mode, max) |
+
+## Usage
+
+```python
+from falcon.contrib import HypercubeMappingPrior
+
+# Define priors for 3 parameters
+prior = HypercubeMappingPrior(
+    priors=[
+        ('uniform', -10.0, 10.0),
+        ('normal', 0.0, 1.0),
+        ('triangular', -1.0, 0.0, 1.0),
+    ]
+)
+
+# Sample from prior
+samples = prior.simulate_batch(1000)
+
+# Transform to/from hypercube space
+u = prior.inverse(samples)   # To hypercube
+x = prior.forward(u)         # From hypercube
+```
+
+## YAML Configuration
+
+```yaml
+simulator:
+  _target_: falcon.contrib.HypercubeMappingPrior
+  priors:
+    - ['uniform', -10.0, 10.0]
+    - ['normal', 0.0, 1.0]
+  hypercube_range: [-2, 2]
+```
+
+## Class Reference
+
+::: falcon.contrib.hypercubemappingprior.HypercubeMappingPrior
+    options:
+      show_source: true
+      members:
+        - __init__
+        - forward
+        - inverse
+        - simulate_batch

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,49 @@
+# API Reference
+
+This section documents Falcon's Python API.
+
+## Package Structure
+
+```
+falcon/
+├── core/           # Core framework
+│   ├── graph       # Graph and Node definitions
+│   ├── deployed_graph  # Runtime execution
+│   └── base_estimator  # Estimator interface
+└── contrib/        # Built-in implementations
+    ├── SNPE_A      # Neural posterior estimation
+    ├── hypercubemappingprior  # Prior distributions
+    └── flow        # Normalizing flows
+```
+
+## Core Classes
+
+| Class | Description |
+|-------|-------------|
+| [`Graph`](graph.md) | Container for computational graph nodes |
+| [`Node`](graph.md#falcon.core.graph.Node) | Single random variable in the graph |
+| [`DeployedGraph`](deployed-graph.md) | Runtime orchestration with Ray |
+| [`BaseEstimator`](base-estimator.md) | Abstract interface for estimators |
+
+## Contrib Classes
+
+| Class | Description |
+|-------|-------------|
+| [`SNPE_A`](snpe-a.md) | Sequential Neural Posterior Estimation |
+| [`HypercubeMappingPrior`](hypercube-prior.md) | Flexible prior distributions |
+| [`Flow`](flow.md) | Normalizing flow networks |
+
+## Quick Import
+
+```python
+import falcon
+
+# Core
+from falcon import Graph, Node, CompositeNode, DeployedGraph
+
+# Contrib
+from falcon.contrib import SNPE_A, HypercubeMappingPrior, Flow
+
+# Utilities
+from falcon import read_run, load_run, read_samples
+```

--- a/docs/api/snpe-a.md
+++ b/docs/api/snpe-a.md
@@ -1,0 +1,61 @@
+# SNPE_A
+
+Sequential Neural Posterior Estimation (SNPE-A) implementation.
+
+## Overview
+
+`SNPE_A` is the primary estimator in Falcon for learning posterior distributions.
+It uses dual normalizing flows (conditional and marginal) with importance sampling
+for adaptive proposal generation.
+
+Key features:
+
+- Dual flow architecture for posterior and proposal sampling
+- Parameter space normalization via hypercube mapping
+- Importance sampling with effective sample size monitoring
+- Automatic learning rate scheduling and early stopping
+
+## Configuration
+
+SNPE_A is configured via nested dataclasses:
+
+```yaml
+estimator:
+  _target_: falcon.contrib.SNPE_A
+  loop:
+    num_epochs: 300
+    batch_size: 128
+  network:
+    net_type: nsf
+  optimizer:
+    lr: 0.01
+  inference:
+    gamma: 0.5
+```
+
+## Class Reference
+
+::: falcon.contrib.SNPE_A.SNPE_A
+    options:
+      show_source: true
+      members:
+        - __init__
+        - train_step
+        - val_step
+        - sample_prior
+        - sample_posterior
+        - sample_proposal
+        - save
+        - load
+
+## Configuration Classes
+
+::: falcon.contrib.SNPE_A.SNPEConfig
+
+::: falcon.contrib.SNPE_A.NetworkConfig
+
+::: falcon.contrib.SNPE_A.OptimizerConfig
+
+::: falcon.contrib.SNPE_A.InferenceConfig
+
+::: falcon.contrib.stepwise_estimator.TrainingLoopConfig

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,183 @@
+# Configuration
+
+Falcon uses YAML configuration files powered by OmegaConf. This page documents all available options.
+
+## Configuration Sections
+
+### `logging`
+
+Configure experiment tracking:
+
+```yaml
+logging:
+  wandb:
+    enabled: true
+    project: "my-project"
+    entity: "my-team"
+  local:
+    enabled: true
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `wandb.enabled` | bool | `false` | Enable WandB logging |
+| `wandb.project` | str | `"falcon"` | WandB project name |
+| `wandb.entity` | str | `null` | WandB team/entity |
+| `local.enabled` | bool | `true` | Enable local file logging |
+
+### `paths`
+
+Configure file paths:
+
+```yaml
+paths:
+  import_path: "."
+  buffer_dir: "sim_dir"
+  graph_dir: "graph_dir"
+  samples_dir: "samples_dir"
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `import_path` | str | `"."` | Path to import custom modules |
+| `buffer_dir` | str | `"sim_dir"` | Simulation buffer directory |
+| `graph_dir` | str | `"graph_dir"` | Trained models directory |
+| `samples_dir` | str | `"samples_dir"` | Output samples directory |
+
+### `buffer`
+
+Configure sample management:
+
+```yaml
+buffer:
+  num_epochs: 500
+  min_total_samples: 1000
+  max_total_samples: 50000
+  resample_interval: 10
+  dump_interval: 50
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `num_epochs` | int | `500` | Total training epochs |
+| `min_total_samples` | int | `1000` | Minimum samples before training |
+| `max_total_samples` | int | `50000` | Maximum samples in buffer |
+| `resample_interval` | int | `10` | Epochs between resampling |
+| `dump_interval` | int | `50` | Epochs between buffer dumps |
+
+### `graph`
+
+Define the computational graph. Each key is a node name:
+
+```yaml
+graph:
+  node_name:
+    parents: [parent1, parent2]    # Forward model dependencies
+    evidence: [evidence1]          # Inference dependencies
+    scaffolds: [scaffold1]         # Additional conditioning
+    observed: "./path/to/data.npz" # Observation file
+    resample: false                # Enable adaptive resampling
+
+    simulator:                     # Forward model
+      _target_: module.ClassName
+      param1: value1
+
+    estimator:                     # Posterior learner (optional)
+      _target_: falcon.contrib.SNPE_A
+      loop:
+        num_epochs: 300
+      network:
+        net_type: nsf
+      optimizer:
+        lr: 0.01
+      inference:
+        gamma: 0.5
+
+    ray:                          # Ray actor configuration
+      num_gpus: 0
+      num_cpus: 1
+```
+
+## Node Configuration
+
+### `simulator`
+
+The forward model that generates samples:
+
+```yaml
+simulator:
+  _target_: falcon.contrib.HypercubeMappingPrior
+  priors:
+    - ['uniform', -10.0, 10.0]
+    - ['normal', 0.0, 1.0]
+```
+
+### `estimator`
+
+The posterior learner (typically SNPE_A):
+
+```yaml
+estimator:
+  _target_: falcon.contrib.SNPE_A
+
+  loop:
+    num_epochs: 300
+    batch_size: 128
+    val_fraction: 0.1
+    patience: 50
+
+  network:
+    net_type: nsf          # nsf, maf, zuko_nice, etc.
+    theta_norm: true
+    embedding:
+      _target_: model.Embedding
+      _input_: [x]
+
+  optimizer:
+    lr: 0.01
+    lr_decay_factor: 0.1
+    scheduler_patience: 8
+
+  inference:
+    gamma: 0.5             # Proposal width (0=posterior, 1=prior)
+    discard_samples: true
+```
+
+### `ray`
+
+Per-node Ray resource allocation:
+
+```yaml
+ray:
+  num_gpus: 1
+  num_cpus: 2
+```
+
+## Global Ray Configuration
+
+```yaml
+ray:
+  num_cpus: 8
+  num_gpus: 1
+  object_store_memory: 1000000000
+```
+
+## Observation Syntax
+
+Load data from NPZ files with optional key extraction:
+
+```yaml
+# Single-key NPZ (auto-extracted)
+observed: "./data/obs.npz"
+
+# Specific key extraction
+observed: "./data/obs.npz['x']"
+```
+
+## Overriding Configuration
+
+Override any parameter via CLI:
+
+```bash
+falcon launch buffer.num_epochs=1000 graph.theta.estimator.optimizer.lr=0.001
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,124 @@
+# Getting Started
+
+This guide walks you through setting up and running your first Falcon project.
+
+## Prerequisites
+
+- Python 3.9+
+- PyTorch 2.0+
+
+## Installation
+
+```bash
+pip install falcon
+```
+
+## Project Structure
+
+A typical Falcon project has this structure:
+
+```
+my_project/
+├── config.yaml      # Graph and training configuration
+├── model.py         # Your simulator and embedding definitions
+└── data/
+    └── obs.npz      # Observed data (optional)
+```
+
+## Minimal Example
+
+### 1. Define Your Simulator
+
+Create `model.py` with a forward model:
+
+```python
+import numpy as np
+
+class Simulator:
+    """Simple Gaussian simulator."""
+
+    def sample(self, batch_dim, parent_conditions=[]):
+        theta = parent_conditions[0]  # Parameters from parent node
+        noise = np.random.randn(*theta.shape) * 0.1
+        return theta + noise
+```
+
+### 2. Create Configuration
+
+Create `config.yaml`:
+
+```yaml
+logging:
+  wandb:
+    enabled: false
+  local:
+    enabled: true
+
+paths:
+  import_path: "."
+
+buffer:
+  num_epochs: 100
+  min_total_samples: 1000
+  max_total_samples: 10000
+
+graph:
+  theta:
+    evidence: [x]
+    simulator:
+      _target_: falcon.contrib.HypercubeMappingPrior
+      priors:
+        - ['uniform', -10.0, 10.0]
+    estimator:
+      _target_: falcon.contrib.SNPE_A
+      loop:
+        num_epochs: 100
+      network:
+        net_type: nsf
+
+  x:
+    parents: [theta]
+    simulator:
+      _target_: model.Simulator
+    observed: "./data/obs.npz['x']"
+```
+
+### 3. Prepare Observation Data
+
+```python
+import numpy as np
+
+# Generate synthetic observation
+true_theta = 2.5
+obs = true_theta + np.random.randn(100) * 0.1
+
+np.savez("data/obs.npz", x=obs)
+```
+
+### 4. Run Training
+
+```bash
+falcon launch --run-dir outputs/run_01
+```
+
+### 5. Sample from Posterior
+
+```bash
+falcon sample posterior --run-dir outputs/run_01
+```
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `falcon launch` | Start training |
+| `falcon sample prior` | Sample from prior |
+| `falcon sample posterior` | Sample from learned posterior |
+| `falcon sample proposal` | Sample from proposal distribution |
+| `falcon graph` | Display graph structure |
+| `falcon monitor` | Launch TUI dashboard |
+
+## Next Steps
+
+- Learn about [Configuration](configuration.md) options
+- Explore the [API Reference](api/index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,56 @@
+# Falcon
+
+**A Python framework for simulation-based inference with adaptive learning.**
+
+Falcon enables adaptive learning of complex conditional distributions through a declarative YAML-based approach. Built on PyTorch, Ray, and the sbi library, it provides automatic parallelization and experiment tracking.
+
+## Key Features
+
+- **Declarative Configuration**: Define probabilistic models using intuitive YAML syntax
+- **Automatic Parallelization**: Distributed execution via Ray actors
+- **Adaptive Learning**: Sequential neural posterior estimation with importance sampling
+- **Experiment Tracking**: Built-in WandB integration for monitoring training
+
+## Quick Example
+
+```yaml
+graph:
+  theta:
+    evidence: [x]
+    simulator:
+      _target_: falcon.contrib.HypercubeMappingPrior
+      priors:
+        - ['uniform', -10.0, 10.0]
+    estimator:
+      _target_: falcon.contrib.SNPE_A
+
+  x:
+    parents: [theta]
+    simulator:
+      _target_: model.Simulator
+    observed: "./data/obs.npz['x']"
+```
+
+```bash
+falcon launch --run-dir outputs/run_01
+```
+
+## Installation
+
+```bash
+pip install falcon
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/cweniger/falcon.git
+cd falcon
+pip install -e .
+```
+
+## Next Steps
+
+- [Getting Started](getting-started.md): Walk through your first Falcon project
+- [Configuration](configuration.md): Learn the YAML configuration format
+- [API Reference](api/index.md): Explore the Python API

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,93 @@
+site_name: Falcon
+site_description: A Python framework for simulation-based inference with adaptive learning
+site_url: https://cweniger.github.io/falcon
+repo_url: https://github.com/cweniger/falcon
+repo_name: cweniger/falcon
+
+theme:
+  name: material
+  palette:
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - API Reference:
+      - Overview: api/index.md
+      - Core:
+          - Graph: api/graph.md
+          - DeployedGraph: api/deployed-graph.md
+          - BaseEstimator: api/base-estimator.md
+      - Contrib:
+          - SNPE_A: api/snpe-a.md
+          - HypercubeMappingPrior: api/hypercube-prior.md
+          - Flow: api/flow.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [.]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            signature_crossrefs: true
+            merge_init_into_class: true
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/cweniger/falcon

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,11 @@ setup(
     ],
     extras_require={
         "monitor": ["textual>=0.40.0"],
+        "docs": [
+            "mkdocs>=1.5",
+            "mkdocs-material>=9.0",
+            "mkdocstrings[python]>=0.24",
+        ],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- Add MkDocs + Material theme + mkdocstrings for modern documentation
- Create initial docs: index, getting-started, configuration reference
- Add API reference pages with automatic docstring extraction
- Update README with documentation badge and links
- Add `[docs]` extras to setup.py for easy installation

## Documentation
Live at: https://cweniger.github.io/falcon/

## Test plan
- [x] `mkdocs build` succeeds
- [x] `mkdocs gh-deploy` deployed successfully
- [x] Review docs at https://cweniger.github.io/falcon/

🤖 Generated with [Claude Code](https://claude.ai/code)