### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "falcon-sbi"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI-driven framework for simulation-based inference with large simulators"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version in `pyproject.toml` from 0.2.0 to 0.2.1 (was missed in the squash merge of #35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)