### PR TITLE
Make sbi an optional dependency with lazy error messaging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example:
-          - 01_minimal
-          - 02_bimodal
-          - 04_gaussian
+        include:
+          - example: 01_minimal
+            extras: ".[sbi]"
+          - example: 02_bimodal
+            extras: ".[sbi]"
+          - example: 04_gaussian
+            extras: "."
     steps:
       - uses: actions/checkout@v4
 
@@ -48,7 +51,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -e . pytest
+        run: pip install -e "${{ matrix.extras }}" pytest
 
       - name: Smoke test ${{ matrix.example }}
         run: pytest -m slow -k "${{ matrix.example }}" --tb=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Falcon is a Python framework for simulation-based inference (SBI) that enables adaptive learning of complex conditional distributions. Built on PyTorch, Ray, and the sbi library, it provides a declarative YAML-based approach to defining probabilistic models with automatic parallelization and WandB experiment tracking.
+Falcon is a Python framework for simulation-based inference (SBI) that enables adaptive learning of complex conditional distributions. Built on PyTorch, Ray, and the sbi library, it provides a declarative YAML-based approach to defining probabilistic models with automatic parallelization and optional WandB experiment tracking.
 
 ## Common Commands
 
@@ -26,7 +26,7 @@ falcon sample proposal --run-dir outputs/exp01   # Sample from proposal distribu
 # Visualize graph structure
 falcon graph                                     # Display ASCII graph visualization
 
-# Real-time monitoring (requires: pip install "falcon[monitor]")
+# Real-time monitoring (requires: pip install "falcon-sbi[monitor]")
 falcon monitor                                   # TUI dashboard for training progress
 
 # Run examples
@@ -40,6 +40,7 @@ cd examples/01_minimal && falcon launch --run-dir outputs/run_01
 **Graph System** (`falcon/core/graph.py`, `falcon/core/deployed_graph.py`):
 - `Node`: Represents a random variable with `simulator_cls` (forward model) and `estimator_cls` (posterior learner)
 - `Graph`: Manages node relationships, performs topological sorting for execution order
+- `CompositeNode`: Factory for multi-output simulator nodes with automatic extraction
 - `DeployedGraph`: Orchestrates Ray-based distributed execution of the graph
 
 **Distributed Execution** (`falcon/core/raystore.py`):
@@ -47,9 +48,13 @@ cd examples/01_minimal && falcon launch --run-dir outputs/run_01
 - `DatasetManagerActor`: Centralized dataset orchestration with sample lifecycle (VALIDATION → TRAINING → DISFAVOURED → TOMBSTONE)
 
 **Estimators** (`falcon/estimators/`):
-- `Flow` (`flow.py`): Flow-based posterior estimation with dual flow architecture (NSF, MAF, Zuko flows)
-- `Gaussian` (`gaussian.py`): Full covariance Gaussian posterior with eigendecomposition
-- `StepwiseEstimator`, `LossBasedEstimator` (`base.py`): Base classes for epoch-based training
+- `BaseEstimator` (`falcon/core/base_estimator.py`): Abstract interface defining train/sample/save/load contract
+- `StepwiseEstimator`, `LossBasedEstimator` (`base.py`): Base classes for epoch-based training with early stopping
+- `Flow` (`flow.py`): Flow-based posterior estimation using conditional + marginal flow pair with importance sampling
+- `FlowDensity` (`flow_density.py`): Flow network wrapper around `sbi.neural_nets` (the only file importing `sbi`)
+- `Gaussian` (`gaussian.py`): Factory creating a `LossBasedEstimator` with full covariance Gaussian posterior
+- `EmbeddedPosterior` (`embedded_posterior.py`): Wrapper combining embedding network with posterior model
+- `networks.py`: MLP builder utility
 
 **Priors** (`falcon/priors/`):
 - `Hypercube` (`hypercube.py`): Bidirectional hypercube-to-target distribution mapping
@@ -59,6 +64,16 @@ cd examples/01_minimal && falcon launch --run-dir outputs/run_01
 - `instantiate_embedding` (`builder.py`): Declarative embedding builder supporting nested configurations
 - `LazyOnlineNorm`, `DiagonalWhitener` (`norms.py`): Online normalization utilities
 - `PCAProjector` (`svd.py`): Streaming PCA for dimensionality reduction
+
+**Logging** (`falcon/core/logger.py`, `falcon/core/local_logger.py`, `falcon/core/wandb_logger.py`):
+- `Logger`: Unified logging with pluggable backends
+- `LocalFileBackend`: Chunked NPZ metric storage
+- `WandBBackend`: Optional WandB integration (graceful fallback if wandb not installed)
+
+**Run Analysis** (`falcon/core/run_reader.py`, `falcon/core/run_loader.py`, `falcon/core/samples_reader.py`):
+- `read_run(path)`: Lazy-loaded metric reader for locally logged training runs
+- `load_run(path)`: Unified `Run` object with config, metrics, samples, and observations
+- `read_samples(path)`: Sample set reader with indexing, key access, and filtering
 
 ### Configuration System
 
@@ -106,10 +121,11 @@ graph:
 
 ### Key Design Patterns
 
-- **Lazy Loading**: Classes defined as strings (`_target_`), instantiated at runtime via `LazyLoader`
+- **Lazy Loading**: Classes defined as strings (`_target_`), instantiated at runtime via `LazyLoader` (`falcon/core/utils.py`)
 - **Ray Actors**: All distributed computation uses Ray actor model
 - **Declarative Configuration**: YAML drives model/training decisions
 - **Async Operations**: asyncio for efficient resource utilization in actors
+- **Optional Dependencies**: `wandb` uses try/except in `wandb_logger.py`; `sbi` is isolated to `flow_density.py`
 
 ## Output Structure
 
@@ -130,13 +146,17 @@ graph:
 
 ## Key Files
 
-- `falcon/cli.py`: Entry point, implements `launch_mode` and `sample_mode`
-- `falcon/core/graph.py`: Graph and Node class definitions
+- `falcon/cli.py`: Entry point, implements `launch_mode`, `sample_mode`, `graph_mode`, `monitor_mode`
+- `falcon/core/graph.py`: Graph, Node, and CompositeNode definitions
 - `falcon/core/deployed_graph.py`: Runtime execution with Ray
-- `falcon/estimators/flow.py`: Flow-based posterior estimation (main inference algorithm)
-- `falcon/estimators/gaussian.py`: Gaussian posterior estimation
+- `falcon/core/base_estimator.py`: Abstract estimator interface
+- `falcon/core/logger.py`: Unified logging system with pluggable backends
+- `falcon/core/run_loader.py`: Unified `Run` loader for post-training analysis
+- `falcon/estimators/flow.py`: Flow-based posterior estimation (conditional + marginal flows)
+- `falcon/estimators/flow_density.py`: sbi-backed flow networks (only sbi import point)
+- `falcon/estimators/gaussian.py`: Gaussian posterior estimation via LossBasedEstimator
 - `falcon/priors/hypercube.py`: Hypercube mapping prior distribution
 - `falcon/priors/product.py`: Product prior with latent space transformations
 - `falcon/embeddings/builder.py`: Declarative embedding pipeline builder
-- `falcon/contrib/`: Backward-compatibility shims (re-exports from new locations)
-- `examples/01_minimal/`: Best starting point for understanding the framework
+- `falcon/interactive.py`: Interactive TUI display for launch mode
+- `examples/`: 01_minimal, 02_bimodal, 03_composite, 04_gaussian, 05_linear_regression

--- a/falcon/core/wandb_logger.py
+++ b/falcon/core/wandb_logger.py
@@ -1,7 +1,7 @@
 """
 WandB logging backend.
 
-Logs metrics to Weights & Biases. Optional dependency - install with: pip install wandb
+Logs metrics to Weights & Biases. Optional dependency - install with: pip install falcon-sbi[wandb]
 """
 
 import logging
@@ -22,7 +22,8 @@ def _check_wandb_available():
     """Raise ImportError if wandb is not installed."""
     if not WANDB_AVAILABLE:
         raise ImportError(
-            "WandB is not installed. Install it with: pip install wandb"
+            "wandb is required for WandB logging.\n"
+            "Install it with: pip install falcon-sbi[wandb]"
         )
 
 

--- a/falcon/estimators/__init__.py
+++ b/falcon/estimators/__init__.py
@@ -2,6 +2,8 @@
 
 Provides Flow (normalizing flow) and Gaussian posterior estimators,
 along with base classes for building custom estimators.
+
+Flow requires the sbi package: pip install falcon-sbi[sbi]
 """
 
 from falcon.estimators.base import (
@@ -10,11 +12,6 @@ from falcon.estimators.base import (
     TrainingLoopConfig,
     OptimizerConfig,
     InferenceConfig,
-)
-from falcon.estimators.flow import (
-    Flow,
-    FlowConfig,
-    NetworkConfig,
 )
 from falcon.estimators.gaussian import (
     Gaussian,
@@ -37,3 +34,20 @@ __all__ = [
     "OptimizerConfig",
     "InferenceConfig",
 ]
+
+# Lazy imports for sbi-dependent classes
+_LAZY_IMPORTS = {
+    "Flow": "falcon.estimators.flow",
+    "FlowConfig": "falcon.estimators.flow",
+    "NetworkConfig": "falcon.estimators.flow",
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        import importlib
+        module = importlib.import_module(_LAZY_IMPORTS[name])
+        attr = getattr(module, name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,9 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "wandb>=0.15.0",
     "torch>=2.0.0",
     "numpy>=1.16",
     "ray>=2.0",
-    "sbi>=0.18",
     "omegaconf>=2.1",
     "coolname>=1.0",
     "rich>=13.0",
@@ -30,7 +28,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+sbi = ["sbi>=0.18"]
+wandb = ["wandb>=0.15.0"]
 monitor = ["textual>=0.40.0"]
+all = ["sbi>=0.18", "wandb>=0.15.0", "textual>=0.40.0"]
 docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "torch>=2.0.0",
     "numpy>=1.16",
     "ray>=2.0",
+    "joblib>=1.0",
     "omegaconf>=2.1",
     "coolname>=1.0",
     "rich>=13.0",


### PR DESCRIPTION
## Summary
- Move `sbi` and `wandb` from hard dependencies to optional extras (`pip install falcon-sbi[sbi]`, `falcon-sbi[wandb]`, or `falcon-sbi[all]`)
- Defer `sbi` import in `flow_density.py` to a lazy `_get_net_builders()` helper so importing `falcon` or `falcon.estimators` never triggers `sbi` at module level
- Make `Flow`/`FlowConfig`/`NetworkConfig` lazy in `estimators/__init__.py` so users of Gaussian estimators don't need `sbi` installed
- Update CLAUDE.md to reflect current codebase structure (fix stale references, add missing files/sections)

## Test plan
- [x] `from falcon.estimators import Gaussian` works without sbi
- [x] `from falcon.estimators import Flow` works when sbi is installed
- [x] `_get_net_builders()` returns all 13 network builders
- [x] Existing test suite passes (10/11 — 1 failure is pre-existing Ray resource issue)
- [x] Verify on a clean environment without sbi that `FlowDensity` raises clear `ImportError`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)