### PR TITLE
Rename CLI options: --output/-o and --config/-c

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,14 @@ pip install .
 
 # Training
 falcon launch                                    # Run with default config
-falcon launch --run-dir outputs/exp01            # Specify output directory
+falcon launch -o outputs/exp01                   # Specify output directory
 falcon launch buffer.num_epochs=500              # Override config parameters
-falcon launch --config-name config_amortized     # Use alternate config file
+falcon launch -c config_amortized                # Use alternate config file
 
 # Sampling (after training)
-falcon sample prior --run-dir outputs/exp01      # Sample from prior
-falcon sample posterior --run-dir outputs/exp01  # Sample from posterior
-falcon sample proposal --run-dir outputs/exp01   # Sample from proposal distribution
+falcon sample prior -o outputs/exp01             # Sample from prior
+falcon sample posterior -o outputs/exp01         # Sample from posterior
+falcon sample proposal -o outputs/exp01          # Sample from proposal distribution
 
 # Visualize graph structure
 falcon graph                                     # Display ASCII graph visualization
@@ -30,7 +30,7 @@ falcon graph                                     # Display ASCII graph visualiza
 falcon monitor                                   # TUI dashboard for training progress
 
 # Run examples
-cd examples/01_minimal && falcon launch --run-dir outputs/run_01
+cd examples/01_minimal && falcon launch -o outputs/run_01
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Run the minimal example (a 3-parameter Gaussian inference problem):
 
 ```bash
 cd examples/01_minimal
-falcon launch --run-dir outputs/run_01
-falcon sample posterior --run-dir outputs/run_01
+falcon launch -o outputs/run_01
+falcon sample posterior -o outputs/run_01
 ```
 
 This trains a neural posterior estimator on simulated data, then draws 1000 posterior samples. Results are saved under `outputs/run_01/`.
@@ -62,8 +62,8 @@ graph:
 ## CLI
 
 ```bash
-falcon launch [--run-dir DIR] [--config-name NAME] [key=value ...]
-falcon sample prior|posterior|proposal --run-dir DIR
+falcon launch [-o DIR] [-c CONFIG] [key=value ...]
+falcon sample prior|posterior|proposal -o DIR
 falcon graph                            # Visualize graph structure
 falcon monitor                          # Real-time TUI dashboard (requires pip install "falcon[monitor]")
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,13 +98,13 @@ np.savez("data/obs.npz", x=obs)
 ### 4. Run Training
 
 ```bash
-falcon launch --run-dir outputs/run_01
+falcon launch -o outputs/run_01
 ```
 
 ### 5. Sample from Posterior
 
 ```bash
-falcon sample posterior --run-dir outputs/run_01
+falcon sample posterior -o outputs/run_01
 ```
 
 ## CLI Commands

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ graph:
 ```
 
 ```bash
-falcon launch --run-dir outputs/run_01
+falcon launch -o outputs/run_01
 ```
 
 ## Installation

--- a/examples/01_minimal/config.yml
+++ b/examples/01_minimal/config.yml
@@ -16,15 +16,15 @@
 #   sample   – Sampling parameters for posterior draws after training.
 #
 # Usage:
-#   falcon launch --run-dir outputs/my_run
+#   falcon launch -o outputs/my_run
 #   falcon launch  # auto-generates: outputs/adj-noun-YYMMDD-HHMM
-#   falcon sample posterior --run-dir outputs/my_run
+#   falcon sample posterior -o outputs/my_run
 #
 # Notes:
 #   • All outputs (simulations, trained models, logs) are written under
-#     ${run_dir}, which is set via --run-dir or auto-generated.
+#     ${run_dir}, which is set via --output or auto-generated.
 #   • ${run_dir} is referenced by buffer, graph, and WandB logging paths.
-#   • Resuming: specify existing --run-dir to load saved config.yaml
+#   • Resuming: specify existing --output to load saved config.yaml
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/examples/04_gaussian/config.yml
+++ b/examples/04_gaussian/config.yml
@@ -16,8 +16,8 @@
 # Usage:
 #   cd examples/04_gaussian
 #   python data/gen_mock_data.py          # Generate mock observation data
-#   falcon launch --run-dir outputs/run   # Train the model
-#   falcon sample posterior --run-dir outputs/run  # Generate posterior samples
+#   falcon launch -o outputs/run           # Train the model
+#   falcon sample posterior -o outputs/run # Generate posterior samples
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/examples/04_gaussian/run_example.py
+++ b/examples/04_gaussian/run_example.py
@@ -118,7 +118,7 @@ def main():
 
     # Step 1: Run falcon launch
     if not run_command(
-        ["falcon", "launch", f"--run-dir={RUN_DIR}"],
+        ["falcon", "launch", f"--output={RUN_DIR}"],
         "Step 1: Running falcon launch",
         cwd=script_dir
     ):
@@ -126,7 +126,7 @@ def main():
 
     # Step 2: Generate posterior samples
     if not run_command(
-        ["falcon", "sample", "posterior", f"--run-dir={RUN_DIR}"],
+        ["falcon", "sample", "posterior", f"--output={RUN_DIR}"],
         "Step 2: Generating posterior samples",
         cwd=script_dir
     ):

--- a/examples/05_linear_regression/config.yml
+++ b/examples/05_linear_regression/config.yml
@@ -15,8 +15,8 @@
 # Usage:
 #   cd examples/05_linear_regression
 #   python data/gen_mock_data.py
-#   falcon launch --run-dir outputs/run
-#   falcon sample posterior --run-dir outputs/run
+#   falcon launch -o outputs/run
+#   falcon sample posterior -o outputs/run
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/examples/05_linear_regression/run_example.py
+++ b/examples/05_linear_regression/run_example.py
@@ -124,7 +124,7 @@ def main():
 
     # Step 1: Run falcon launch
     if not run_command(
-        ["falcon", "launch", f"--run-dir={RUN_DIR}"],
+        ["falcon", "launch", f"--output={RUN_DIR}"],
         "Step 1: Running falcon launch",
         cwd=script_dir
     ):
@@ -132,7 +132,7 @@ def main():
 
     # Step 2: Generate posterior samples
     if not run_command(
-        ["falcon", "sample", "posterior", f"--run-dir={RUN_DIR}"],
+        ["falcon", "sample", "posterior", f"--output={RUN_DIR}"],
         "Step 2: Generating posterior samples",
         cwd=script_dir
     ):

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 """
 Falcon Adaptive Training - Standalone CLI Tool
-Usage: falcon launch [--run-dir DIR] [--config-name FILE] [key=value ...]
-       falcon sample prior|posterior|proposal [--run-dir DIR] [--config-name FILE] [key=value ...]
-       falcon graph [--config-name FILE]
+Usage: falcon launch [--output DIR] [--config FILE] [key=value ...]
+       falcon sample prior|posterior|proposal [--output DIR] [--config FILE] [key=value ...]
+       falcon graph [--config FILE]
 
 Run directory behavior:
-  - If --run-dir not specified, generates: outputs/adj-noun-YYMMDD-HHMM
-  - If --run-dir exists with config.yml, resumes from saved config
-  - Otherwise, loads ./config.yml and saves resolved config to run_dir
+  - If --output not specified, generates: outputs/adj-noun-YYMMDD-HHMM
+  - If --output exists with config.yml, resumes from saved config
+  - Otherwise, loads ./config.yml and saves resolved config to output dir
 """
 
 import sys
 import os
+import warnings
 from pathlib import Path
 
 BANNER = "falcon \x1b[2m\u2581\u2582\u2585\u2587\u2588\u2586\u2583\u2582\u2581\u2581\x1b[0m"
@@ -732,13 +733,13 @@ def parse_args():
         print(f"{BANNER} v{_get_version()}")
         print()
         print("Usage:")
-        print("  falcon launch [--run-dir DIR] [--config-name FILE] [--no-interactive] [key=value ...]")
-        print("  falcon sample prior|posterior|proposal [--run-dir DIR] [--config-name FILE] [key=value ...]")
-        print("  falcon graph [--config-name FILE]")
+        print("  falcon launch [--output DIR] [--config FILE] [--no-interactive] [key=value ...]")
+        print("  falcon sample prior|posterior|proposal [--output DIR] [--config FILE] [key=value ...]")
+        print("  falcon graph [--config FILE]")
         print()
         print("Options:")
-        print("  --run-dir DIR          Run directory (default: auto-generated)")
-        print("  --config-name FILE     Config file (default: config.yml)")
+        print("  -o, --output DIR       Output directory (default: auto-generated)")
+        print("  -c, --config FILE      Config file (default: config.yml)")
         print("  --no-interactive       Disable interactive TUI (plain output)")
         print("  --log-lines N          Number of log lines in interactive footer (default: 16)")
         print("  --no-posterior-sample  Skip posterior sampling after training")
@@ -775,7 +776,7 @@ def parse_args():
             sys.exit(1)
         sample_type = args.pop(0)
 
-    # Extract --run-dir, --config-name, --interactive, --log-lines and collect overrides
+    # Extract --output, --config, --interactive, --log-lines and collect overrides
     run_dir = None
     config_name = "config.yml"
     # Interactive mode: default to True if stdout is a TTY
@@ -787,15 +788,29 @@ def parse_args():
     i = 0
     while i < len(args):
         arg = args[i]
-        if arg == "--run-dir" and i + 1 < len(args):
+        if arg in ("--output", "-o") and i + 1 < len(args):
+            run_dir = args[i + 1]
+            i += 1
+        elif arg.startswith("--output="):
+            run_dir = arg.split("=", 1)[1]
+        elif arg == "--run-dir" and i + 1 < len(args):
+            warnings.warn("--run-dir is deprecated, use --output or -o instead", FutureWarning, stacklevel=2)
             run_dir = args[i + 1]
             i += 1
         elif arg.startswith("--run-dir="):
+            warnings.warn("--run-dir is deprecated, use --output or -o instead", FutureWarning, stacklevel=2)
             run_dir = arg.split("=", 1)[1]
+        elif arg in ("--config", "-c") and i + 1 < len(args):
+            config_name = args[i + 1]
+            i += 1
+        elif arg.startswith("--config="):
+            config_name = arg.split("=", 1)[1]
         elif arg == "--config-name" and i + 1 < len(args):
+            warnings.warn("--config-name is deprecated, use --config or -c instead", FutureWarning, stacklevel=2)
             config_name = args[i + 1]
             i += 1
         elif arg.startswith("--config-name="):
+            warnings.warn("--config-name is deprecated, use --config or -c instead", FutureWarning, stacklevel=2)
             config_name = arg.split("=", 1)[1]
         elif arg in ("--interactive", "-i"):
             interactive = True

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -55,8 +55,8 @@ def test_example_runs_without_error(example_name, config_name, epoch_overrides, 
     cmd = [
         "falcon",
         "launch",
-        f"--config-name={config_name}",
-        f"--run-dir={tmp_path}",
+        f"--config={config_name}",
+        f"--output={tmp_path}",
         # Reduce sample counts for faster testing
         "buffer.min_samples=64",
         "buffer.max_samples=128",


### PR DESCRIPTION
## Summary
- Rename `--run-dir` → `--output` / `-o` and `--config-name` → `--config` / `-c`
- Old flags still work but emit `FutureWarning` deprecation messages
- Updated all docs, examples, and tests to use the new flags

## Test plan
- [x] Verified new flags (`-o`, `-c`, `--output`, `--config`) parse correctly
- [x] Verified deprecated flags (`--run-dir`, `--config-name`) still work and emit warnings
- [ ] Run smoke tests: `pytest tests/test_examples_smoke.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)