### PR TITLE
Fix core/estimator/embedding bugs found during example 06 development

### DIFF
--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -610,6 +610,9 @@ class DeployedGraph:
 
         for name in node_order:
             if name in ref_trace:
+                # FIXME: conditioned nodes are skipped, so their refs are missing
+                # from sample_refs. Callers must manually merge them back (see
+                # training loop). _execute_graph should insert them directly.
                 continue
 
             # Build condition refs for this node (parents always, evidence for inference)

--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -212,7 +212,7 @@ class NodeWrapper:
         elif hasattr(self.estimator_instance, 'history'):
             losses = self.estimator_instance.history.get('val_loss', [])
             if losses:
-                final_loss = losses[-1]
+                final_loss = min(losses)
 
         if final_loss is not None:
             info(f"[{self.name}] Training completed (loss: {final_loss:.4f})")

--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -785,13 +785,25 @@ class DeployedGraph:
                     # no pause needed. Forward simulation runs on separate actors concurrently.
                     proposal_refs = self.sample_proposal(num_new_samples, observations)
                     condition_refs = self._extract_value_refs(proposal_refs)
-                    for key in observations:
-                        condition_refs.pop(key, None)
+                    # Only keep latent nodes (with estimators) from proposal.
+                    # Deterministic intermediates and observed nodes must be
+                    # re-simulated to maintain data consistency.
+                    latent_nodes = {n.name for n in self.graph.node_list
+                                    if n.estimator_cls is not None}
+                    condition_refs = {k: v for k, v in condition_refs.items()
+                                      if k in latent_nodes}
                     sample_refs = self._execute_graph(
                         num_new_samples, self.graph.forward_order, condition_refs, "sample"
                     )
+                    # Only merge latent node values from proposal into
+                    # sample_refs.  Deterministic intermediates (e.g. tokens)
+                    # were correctly re-simulated in _execute_graph above and
+                    # must not be overwritten with observation-based values.
                     for i, prop_ref in enumerate(proposal_refs):
-                        sample_refs[i].update(prop_ref)
+                        sample_refs[i].update(
+                            {k: v for k, v in prop_ref.items()
+                             if k.split(".")[0] in latent_nodes}
+                        )
                     ray.get(dataset_manager.append_refs.remote(sample_refs))
 
             # Periodic status update (every ~60 seconds)

--- a/falcon/embeddings/norms.py
+++ b/falcon/embeddings/norms.py
@@ -47,7 +47,7 @@ class RunningNorm(nn.Module):
 
         if self.training:
             # Compute batch mean and variance over specified dims
-            batch_mean = x.mean(dim=dim, keepdim=True)
+            batch_mean = x.mean(dim=dim, keepdim=True).detach()
             batch_var = ((x - self.running_mean) ** 2).mean(dim=dim, keepdim=True).detach()
 
             if self.adaptive_momentum:

--- a/falcon/estimators/base.py
+++ b/falcon/estimators/base.py
@@ -632,7 +632,10 @@ class LossBasedEstimator(StepwiseEstimator):
 
     def sample_posterior(self, num_samples: int, conditions: Optional[Dict] = None) -> dict:
         """Sample from the posterior distribution q(theta|x)."""
-        return self._sample(num_samples, conditions, gamma=None)
+        # TODO: refactor — this corrects for the bias from training on proposal data.
+        gamma = self.inference_config.gamma
+        gamma_correct = (1 + gamma) / gamma if gamma is not None else None
+        return self._sample(num_samples, conditions, gamma=gamma_correct)
 
     def sample_proposal(self, num_samples: int, conditions: Optional[Dict] = None) -> dict:
         """Sample from widened proposal distribution for adaptive resampling."""

--- a/falcon/estimators/gaussian.py
+++ b/falcon/estimators/gaussian.py
@@ -109,13 +109,14 @@ class GaussianPosterior(nn.Module):
         self.register_buffer("_input_std", torch.ones(condition_dim))
 
         # Output statistics (theta) - diagonal whitening
-        self.register_buffer("_output_mean", torch.zeros(param_dim))
-        self.register_buffer("_output_std", torch.ones(param_dim))
+        # Always float64 for precision; results are cast to input dtype on output.
+        self.register_buffer("_output_mean", torch.zeros(param_dim, dtype=torch.float64))
+        self.register_buffer("_output_std", torch.ones(param_dim, dtype=torch.float64))
 
         # Residual covariance (prediction error) - full covariance
-        self.register_buffer("_residual_cov", torch.eye(param_dim))
-        self.register_buffer("_residual_eigvals", torch.ones(param_dim))
-        self.register_buffer("_residual_eigvecs", torch.eye(param_dim))
+        self.register_buffer("_residual_cov", torch.eye(param_dim, dtype=torch.float64))
+        self.register_buffer("_residual_eigvals", torch.ones(param_dim, dtype=torch.float64))
+        self.register_buffer("_residual_eigvecs", torch.eye(param_dim, dtype=torch.float64))
 
     # ==================== Device/Dtype ====================
 
@@ -150,22 +151,26 @@ class GaussianPosterior(nn.Module):
         r_proj = V.T @ residuals.T
         mahal = (r_proj**2 / d.unsqueeze(1)).sum(dim=0)
 
-        return -0.5 * (self.param_dim * np.log(2 * np.pi) + log_det + mahal)
+        return (-0.5 * (self.param_dim * np.log(2 * np.pi) + log_det + mahal)).to(theta.dtype)
 
     def sample(self, conditions: torch.Tensor, gamma: Optional[float] = None) -> torch.Tensor:
         """Sample from posterior, optionally tempered.
+
+        Internal computation is float64 (output buffer precision).
+        Result is cast to conditions' dtype on return.
 
         Args:
             conditions: Condition tensor of shape (batch, condition_dim)
             gamma: Tempering parameter. None = untempered, <1 = widened.
         """
+        out_dtype = conditions.dtype
         mean = self._forward_mean(conditions)
         V = self._residual_eigvecs
         d = self._residual_eigvals
 
         if gamma is None:
             eps = torch.randn_like(mean)
-            return mean + (V @ (torch.sqrt(d).unsqueeze(1) * eps.T)).T
+            return (mean + (V @ (torch.sqrt(d).unsqueeze(1) * eps.T)).T).to(out_dtype)
 
         # Tempered sampling
         a = gamma / (1 + gamma)
@@ -178,7 +183,7 @@ class GaussianPosterior(nn.Module):
         mean_prop = (V @ (alpha.unsqueeze(1) * mean_proj)).T
 
         eps = torch.randn_like(mean)
-        return mean_prop + (V @ (torch.sqrt(var_prop).unsqueeze(1) * eps.T)).T
+        return (mean_prop + (V @ (torch.sqrt(var_prop).unsqueeze(1) * eps.T)).T).to(out_dtype)
 
     # ==================== Internal Methods ====================
 
@@ -197,8 +202,8 @@ class GaussianPosterior(nn.Module):
     def _update_stats(self, theta: torch.Tensor, conditions: torch.Tensor) -> None:
         """Update running statistics using EMA.
 
-        Uses non-in-place ops so output buffers auto-promote to theta's dtype.
-        Input buffers stay in MLP dtype; conditions are cast accordingly.
+        Output buffers are float64 for precision. Input buffers stay in MLP
+        dtype (float32); conditions are cast accordingly.
         """
         m = self.momentum
         with torch.no_grad():


### PR DESCRIPTION
Four independent bug fixes surfaced while developing example 06 (spectral analysis with intermediate deterministic nodes). All changes are self-contained and safe to merge independently of that example.

## Fixes

**`falcon/core/deployed_graph.py`**
- Report best validation loss (not last) in training completion message
- Fix proposal re-simulation corrupting deterministic intermediate nodes: previously, observation-based values for nodes like `tokens` were overwriting freshly re-simulated values, producing inconsistent `(theta, x)` training pairs. Now only latent nodes (those with estimators) are propagated from the proposal; deterministic intermediates are always re-derived from forward simulation.

**`falcon/estimators/base.py`**
- `sample_posterior` was not correcting for the bias introduced by training on proposal data. Now applies the analytical `(1+γ)/γ` correction that inverts the tempering used during proposal generation. This is the complementary analytical correction described in #48 (the full importance reweighting for heterogeneous buffers remains open there).

**`falcon/estimators/gaussian.py`**
- `GaussianPosterior` output buffers were float32 by default. For parameters with tight priors (e.g. f₀ ~ 2.75×10⁻³ with CRB ~5×10⁻¹⁰), float32 ULP is comparable to the posterior width, making learning effectively impossible. Output buffers are now always float64; results are cast to the caller's dtype on return.

**`falcon/embeddings/norms.py`**
- `RunningNorm` was not detaching `batch_mean`, causing gradients to flow through the running statistics — wasteful and incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)