### PR TITLE
Remove pause/resume; simplify interrupt to _terminated flag

### DIFF
--- a/examples/02_bimodal/config_amortized.yml
+++ b/examples/02_bimodal/config_amortized.yml
@@ -48,7 +48,6 @@ graph:
         num_epochs: 300
         batch_size: 128
         early_stop_patience: 32
-        reset_network_after_pause: false
       network:
         net_type: nsf  # zuko_gf, maf, nice, sospf, naf, gf
         theta_norm: true

--- a/examples/02_bimodal/config_regular.yml
+++ b/examples/02_bimodal/config_regular.yml
@@ -48,7 +48,6 @@ graph:
         num_epochs: 300
         batch_size: 128
         early_stop_patience: 32
-        reset_network_after_pause: false
       network:
         net_type: nsf  # zuko_gf, maf, nice, sospf, naf, gf
         theta_norm: true

--- a/examples/02_bimodal/config_rounds_fill.yml
+++ b/examples/02_bimodal/config_rounds_fill.yml
@@ -48,7 +48,6 @@ graph:
         num_epochs: 300
         batch_size: 128
         early_stop_patience: 32
-        reset_network_after_pause: false
       network:
         net_type: nsf  # zuko_gf, maf, nice, sospf, naf, gf
         theta_norm: true

--- a/examples/02_bimodal/config_rounds_renew.yml
+++ b/examples/02_bimodal/config_rounds_renew.yml
@@ -48,7 +48,6 @@ graph:
         num_epochs: 600
         batch_size: 128
         early_stop_patience: 32
-        reset_network_after_pause: false
       network:
         net_type: nsf  # zuko_gf, maf, nice, sospf, naf, gf
         theta_norm: true

--- a/examples/03_composite/config.yml
+++ b/examples/03_composite/config.yml
@@ -50,7 +50,6 @@ graph:
         num_epochs: 300
         batch_size: 128
         early_stop_patience: 32
-        reset_network_after_pause: false
       network:
         net_type: zuko_gf # nsf, zuko_gf, maf, nice, sospf, naf, gf
         theta_norm: true
@@ -97,7 +96,6 @@ graph:
         num_epochs: 300
         batch_size: 128
         early_stop_patience: 32
-        reset_network_after_pause: false
       network:
         net_type: nsf # nsf, zuko_gf, maf, nice, sospf, naf, gf
         theta_norm: true

--- a/falcon/core/base_estimator.py
+++ b/falcon/core/base_estimator.py
@@ -100,16 +100,6 @@ class BaseEstimator(ABC):
         pass
 
     @abstractmethod
-    def pause(self) -> None:
-        """Pause training loop."""
-        pass
-
-    @abstractmethod
-    def resume(self) -> None:
-        """Resume training loop."""
-        pass
-
-    @abstractmethod
     def interrupt(self) -> None:
         """Terminate training loop."""
         pass

--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -114,11 +114,10 @@ class MultiplexNodeWrapper:
         return []
 
 
-# TODO: NodeWrapper is async solely because train() needs to yield for pause/resume.
+# TODO: NodeWrapper is async solely because train() uses asyncio.sleep(0) to yield.
 # This makes every ray.get inside the actor (e.g. CachedDataLoader) block the event
 # loop and trigger warnings. Consider splitting into separate training and sampling
-# actors — sampling reads best_model which is independent of training state, so it
-# doesn't actually need to pause training. Weight sync on validation improvement only.
+# actors — sampling reads best_model which is independent of training state.
 @ray.remote
 class NodeWrapper:
     def __init__(self, node, graph, model_path=None, log_config=None):
@@ -408,18 +407,6 @@ class NodeWrapper:
         if self.estimator_instance is not None:
             node_dir.mkdir(parents=True, exist_ok=True)
             return self.estimator_instance.load(node_dir)
-
-    def pause(self):
-        if self.estimator_instance is not None:
-            return self.estimator_instance.pause()
-
-    def resume(self):
-        if self.estimator_instance is not None:
-            return self.estimator_instance.resume()
-
-    def interrupt(self):
-        if self.estimator_instance is not None:
-            return self.estimator_instance.interrupt()
 
     def get_status(self) -> dict:
         """Return current status for monitoring."""
@@ -872,26 +859,3 @@ class DeployedGraph:
             load_futures.append(load_future)
         ray.get(load_futures)
 
-    def pause(self):
-        """Pause all nodes in the deployed graph."""
-        pause_futures = []
-        for _, node in self.wrapped_nodes_dict.items():
-            pause_future = node.pause.remote()
-            pause_futures.append(pause_future)
-        ray.get(pause_futures)
-
-    def resume(self):
-        """Resume all nodes in the deployed graph."""
-        resume_futures = []
-        for _, node in self.wrapped_nodes_dict.items():
-            resume_future = node.resume.remote()
-            resume_futures.append(resume_future)
-        ray.get(resume_futures)
-
-    def interrupt(self):
-        """Interrupt all nodes in the deployed graph."""
-        interrupt_futures = []
-        for _, node in self.wrapped_nodes_dict.items():
-            interrupt_future = node.interrupt.remote()
-            interrupt_futures.append(interrupt_future)
-        ray.get(interrupt_futures)

--- a/falcon/estimators/base.py
+++ b/falcon/estimators/base.py
@@ -25,7 +25,6 @@ class TrainingLoopConfig:
     num_epochs: int = 100
     batch_size: int = 128
     early_stop_patience: int = 16
-    reset_network_after_pause: bool = False
     cache_sync_every: int = 0  # 0 = sync every epoch, N = sync every N epochs
     max_cache_samples: int = 0  # 0 = cache all, >0 = cache random subset
     cache_on_device: bool = False  # True = cache training data on estimator's device (GPU)
@@ -56,7 +55,7 @@ class StepwiseEstimator(BaseEstimator):
 
     Provides concrete implementations for:
     - train() with epoch iteration and early stopping
-    - pause/resume/interrupt
+    - interrupt
 
     Subclasses must implement:
     - train_step() / val_step() / on_epoch_end()
@@ -89,11 +88,7 @@ class StepwiseEstimator(BaseEstimator):
         self.theta_key = theta_key
         self.condition_keys = condition_keys or []
 
-        # Async control
-        self._pause_event = asyncio.Event()
-        self._pause_event.set()
         self._terminated = False
-        self._break_flag = False
 
         # Networks initialized flag (managed by subclass)
         self.networks_initialized = False
@@ -229,10 +224,6 @@ class StepwiseEstimator(BaseEstimator):
                     log({f"train:{k}": v})
 
                 await asyncio.sleep(0)
-                await self._pause_event.wait()
-                if self._break_flag:
-                    self._break_flag = False
-                    break
 
             train_metrics_avg = {
                 k: v / num_train_batches for k, v in train_metrics_sum.items()
@@ -253,10 +244,6 @@ class StepwiseEstimator(BaseEstimator):
                 num_val_samples += bs
 
                 await asyncio.sleep(0)
-                await self._pause_event.wait()
-                if self._break_flag:
-                    self._break_flag = False
-                    break
 
             val_metrics_avg = {
                 k: v / num_val_samples for k, v in val_metrics_sum.items()
@@ -307,7 +294,6 @@ class StepwiseEstimator(BaseEstimator):
                 info("Early stopping triggered.")
                 break
 
-            await self._pause_event.wait()
             if self._terminated:
                 break
 
@@ -329,23 +315,9 @@ class StepwiseEstimator(BaseEstimator):
         except Exception:
             pass
 
-    # ==================== Pause/Resume/Interrupt ====================
-
-    def pause(self) -> None:
-        """Pause training loop."""
-        self._pause_event.clear()
-
-    def resume(self) -> None:
-        """Resume training loop."""
-        if self.loop_config.reset_network_after_pause:
-            self.networks_initialized = False
-            self._break_flag = True
-        self._pause_event.set()
-
     def interrupt(self) -> None:
         """Terminate training loop."""
         self._terminated = True
-        self._pause_event.set()
 
 
 # ==================== LossBasedEstimator ====================


### PR DESCRIPTION
## Summary

`pause()` and `resume()` were never called anywhere in the execution path. `_pause_event` was always set (initialized via `.set()`, never cleared), making every `await _pause_event.wait()` in the training loop a no-op. `NodeWrapper.interrupt()` and `DeployedGraph.interrupt()` were dead — the only real caller, `NodeWrapper.request_stop()`, calls `estimator_instance.interrupt()` directly.

This removes the dead code and simplifies the interrupt path to a single flag.

## Changes

- Remove `pause()`/`resume()` from `BaseEstimator`, `StepwiseEstimator`, `NodeWrapper`, `DeployedGraph`
- Remove `_pause_event`, `_break_flag`, and the three `await _pause_event.wait()` calls in `_train()`
- Remove `NodeWrapper.interrupt()` and `DeployedGraph.interrupt()` (dead — bypassed by `request_stop`)
- Simplify `StepwiseEstimator.interrupt()` to just `self._terminated = True`
- Remove `reset_network_after_pause` from `TrainingLoopConfig` and 5 example configs

## Relation to open issues

Partially addresses #19: `pause()`/`resume()` were the stated reason `NodeWrapper` needed to be an async actor. That justification is now gone. `NodeWrapper` is still async (due to `asyncio.sleep(0)` yield points in the training loop), but the primary motivation for the design has been removed — making the eventual refactor described in #19 cleaner to implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)