### PR TITLE
Print end-of-run summary at the end of falcon launch

### DIFF
--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -294,12 +294,26 @@ class _GracefulShutdown:
         return self._stopping
 
 
-def _build_run_summary(status, output_dir, cfg, deployed_graph):
+def _fmt_duration(seconds):
+    """Format a duration in seconds as e.g. '4m 23s' or '1h 02m 05s'."""
+    seconds = int(round(seconds))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h {m:02d}m {s:02d}s"
+    if m:
+        return f"{m}m {s:02d}s"
+    return f"{s}s"
+
+
+def _build_run_summary(status, output_dir, cfg, deployed_graph, start_time=None, end_time=None):
     """Build a compact end-of-run summary as a list of text lines.
 
     Always returns something printable even if the monitor bridge is
-    unreachable; per-node details are best-effort.
+    unreachable; per-node details and counts are best-effort.
     """
+    from datetime import datetime
+
     lines = []
     lines.append("=" * 60)
     lines.append(f"falcon launch {status}")
@@ -315,6 +329,25 @@ def _build_run_summary(status, output_dir, cfg, deployed_graph):
     if node_names:
         node_glob = "{" + ",".join(node_names) + "}" if len(node_names) > 1 else node_names[0]
         lines.append(f"         {graph_path / node_glob / 'output.log'}  (per-node)")
+    if start_time is not None:
+        lines.append(f"Started: {datetime.fromtimestamp(start_time):%Y-%m-%d %H:%M:%S}")
+    if end_time is not None:
+        lines.append(f"Ended:   {datetime.fromtimestamp(end_time):%Y-%m-%d %H:%M:%S}")
+    if start_time is not None and end_time is not None:
+        lines.append(f"Runtime: {_fmt_duration(end_time - start_time)}")
+    try:
+        import ray
+        if ray.is_initialized():
+            res = ray.cluster_resources()
+            cpu = int(res.get("CPU", 0))
+            gpu = int(res.get("GPU", 0))
+            mem_gb = res.get("memory", 0) / (1024 ** 3)
+            n_alive = sum(1 for n in ray.nodes() if n.get("Alive"))
+            lines.append(
+                f"Ray:     {n_alive} node(s) | {cpu} CPU, {gpu} GPU, {mem_gb:.1f} GB"
+            )
+    except Exception:
+        pass
     try:
         import ray
         bridge = getattr(deployed_graph, "monitor_bridge", None) if deployed_graph else None
@@ -336,11 +369,20 @@ def _build_run_summary(status, output_dir, cfg, deployed_graph):
                         parts.append(f"{sims} sims")
                     lines.append(f"  {name}: {' | '.join(parts)}")
             buf = status_dict.get("buffer", {})
-            if isinstance(buf, dict) and ("training" in buf or "validation" in buf):
-                lines.append(
-                    f"Buffer:  {buf.get('training', 0)} training, "
-                    f"{buf.get('validation', 0)} validation"
-                )
+            if isinstance(buf, dict):
+                total_generated = buf.get("total_length")
+                if total_generated is not None:
+                    live = buf.get("training", 0) + buf.get("validation", 0)
+                    lines.append(
+                        f"Samples generated: {total_generated} total | "
+                        f"{buf.get('training', 0)} train, {buf.get('validation', 0)} val "
+                        f"({live} live in buffer)"
+                    )
+                elif "training" in buf or "validation" in buf:
+                    lines.append(
+                        f"Buffer:  {buf.get('training', 0)} training, "
+                        f"{buf.get('validation', 0)} validation"
+                    )
     except Exception:
         pass  # Best-effort; the path lines above are the essential receipt
     lines.append("=" * 60)
@@ -431,12 +473,15 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
     """Launch mode: Full training and inference pipeline."""
     import logging
     import threading
+    import time as _time
     import torch
     import ray
     from omegaconf import OmegaConf
     import falcon
     from falcon.core.graph import create_graph_from_config
     from falcon.core.logger import Logger, set_logger, info
+
+    launch_start = _time.time()
 
     # Initialize interactive display or graceful shutdown handler
     display = None
@@ -600,7 +645,6 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
 
     # 4) Launch training & simulations
     # Create stop check callback for graceful shutdown (handles Ctrl+C and timeout)
-    import time as _time
     _start_time = _time.time()
     _timeout_logged = False
 
@@ -670,7 +714,10 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
 
         # Build the end-of-run summary and route it through the driver logger
         # so it lands in driver/output.log (and, in plain mode, on stdout).
-        summary_lines = _build_run_summary(run_status, output_dir, cfg, deployed_graph)
+        summary_lines = _build_run_summary(
+            run_status, output_dir, cfg, deployed_graph,
+            start_time=launch_start, end_time=_time.time(),
+        )
         for line in summary_lines:
             info(line)
 

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -294,6 +294,51 @@ class _GracefulShutdown:
         return self._stopping
 
 
+def _build_run_summary(status, output_dir, cfg, deployed_graph):
+    """Build a compact end-of-run summary as a list of text lines.
+
+    Always returns something printable even if the monitor bridge is
+    unreachable; per-node details are best-effort.
+    """
+    lines = []
+    lines.append("=" * 60)
+    lines.append(f"falcon launch {status}")
+    lines.append(f"Output:  {output_dir}")
+    lines.append(f"Graph:   {cfg.paths.graph}")
+    samples_path = cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir")
+    lines.append(f"Samples: {samples_path}")
+    try:
+        import ray
+        bridge = getattr(deployed_graph, "monitor_bridge", None) if deployed_graph else None
+        if bridge is not None:
+            status_dict = ray.get(bridge.get_status.remote(), timeout=5.0)
+            nodes = status_dict.get("nodes", {})
+            if nodes:
+                lines.append("Nodes:")
+                for name, ns in nodes.items():
+                    parts = [str(ns.get("status", "?"))]
+                    total_epochs = ns.get("total_epochs", 0)
+                    if total_epochs:
+                        parts.append(f"{ns.get('current_epoch', 0)}/{total_epochs} epochs")
+                    loss = ns.get("loss")
+                    if loss is not None:
+                        parts.append(f"loss={loss:.4g}")
+                    sims = ns.get("samples", 0)
+                    if sims:
+                        parts.append(f"{sims} sims")
+                    lines.append(f"  {name}: {' | '.join(parts)}")
+            buf = status_dict.get("buffer", {})
+            if isinstance(buf, dict) and ("training" in buf or "validation" in buf):
+                lines.append(
+                    f"Buffer:  {buf.get('training', 0)} training, "
+                    f"{buf.get('validation', 0)} validation"
+                )
+    except Exception:
+        pass  # Best-effort; the path lines above are the essential receipt
+    lines.append("=" * 60)
+    return lines
+
+
 def _save_samples(samples, sample_cfg, sample_type, graph, cfg, info_fn=print):
     """Save generated samples to disk.
 
@@ -568,6 +613,7 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
                 return True
         return False
 
+    run_status = "completed"
     try:
         deployed_graph.launch(dataset_manager, observations, graph_path=graph_path, stop_check=stop_check)
 
@@ -595,14 +641,38 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
                 info_fn=info,
             )
 
+    except KeyboardInterrupt:
+        run_status = "interrupted"
+        raise
+    except Exception as e:
+        run_status = f"failed ({type(e).__name__}: {e})"
+        raise
     finally:
         ##########################
         ### Clean up resources ###
         ##########################
 
+        # A graceful Ctrl+C / timeout exits the launch normally, not via an
+        # exception, so reflect that here.
+        if run_status == "completed":
+            if (display and display.stop_requested) or (
+                shutdown_handler and shutdown_handler.stop_requested
+            ):
+                run_status = "interrupted"
+
+        # Build the end-of-run summary and route it through the driver logger
+        # so it lands in driver/output.log (and, in plain mode, on stdout).
+        summary_lines = _build_run_summary(run_status, output_dir, cfg, deployed_graph)
+        for line in summary_lines:
+            info(line)
+
         # Stop interactive display first (restores terminal)
         if display:
             display.stop()
+            # The TUI used the alternate screen buffer, so nothing the user
+            # saw survives. Echo the summary to real stdout as the receipt.
+            for line in summary_lines:
+                print(line)
 
         # Uninstall shutdown handler
         if shutdown_handler:

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -327,8 +327,12 @@ def _build_run_summary(status, output_dir, cfg, deployed_graph, start_time=None,
     except Exception:
         node_names = []
     if node_names:
-        node_glob = "{" + ",".join(node_names) + "}" if len(node_names) > 1 else node_names[0]
-        lines.append(f"         {graph_path / node_glob / 'output.log'}  (per-node)")
+        n = len(node_names)
+        if n <= 6:
+            suffix = f"(per-node: {', '.join(node_names)})"
+        else:
+            suffix = f"(per-node, {n} nodes)"
+        lines.append(f"         {graph_path / '<node>' / 'output.log'}  {suffix}")
     if start_time is not None:
         lines.append(f"Started: {datetime.fromtimestamp(start_time):%Y-%m-%d %H:%M:%S}")
     if end_time is not None:

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -304,9 +304,17 @@ def _build_run_summary(status, output_dir, cfg, deployed_graph):
     lines.append("=" * 60)
     lines.append(f"falcon launch {status}")
     lines.append(f"Output:  {output_dir}")
-    lines.append(f"Graph:   {cfg.paths.graph}")
     samples_path = cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir")
     lines.append(f"Samples: {samples_path}")
+    graph_path = Path(cfg.paths.graph)
+    lines.append(f"Logs:    {graph_path / 'driver' / 'output.log'}  (driver)")
+    try:
+        node_names = list(cfg.graph.keys())
+    except Exception:
+        node_names = []
+    if node_names:
+        node_glob = "{" + ",".join(node_names) + "}" if len(node_names) > 1 else node_names[0]
+        lines.append(f"         {graph_path / node_glob / 'output.log'}  (per-node)")
     try:
         import ray
         bridge = getattr(deployed_graph, "monitor_bridge", None) if deployed_graph else None


### PR DESCRIPTION
## Why

When `falcon launch` finishes in TUI mode, the alternate screen buffer is restored on exit and everything the user saw vanishes — there's no trace on the terminal that the run happened or succeeded. Even in plain mode there's no at-a-glance "did this work, where did it go, how long did it take" receipt.

## What

A compact end-of-run summary, emitted via the driver logger (so it lands in `driver/output.log` like everything else, and on stdout in plain mode) and additionally `print()`ed to real stdout after the TUI restores the terminal. Example:

```
============================================================
falcon launch completed
Output:  outputs/run01
Samples: outputs/run01/samples_dir
Logs:    outputs/run01/graph_dir/driver/output.log  (driver)
         outputs/run01/graph_dir/<node>/output.log   (per-node: z, x)
Started: 2026-05-12 06:07:01
Ended:   2026-05-12 06:11:24
Runtime: 4m 23s
Ray:     1 node(s) | 8 CPU, 0 GPU, 16.0 GB
Nodes:
  z: done | 205/300 epochs | loss=-14.4 | 12096 sims
  x: idle
Samples generated: 12160 total | 11904 train, 256 val (12160 live in buffer)
============================================================
```

Details:
- **Status** is tracked: exceptions → `failed (...)`, `KeyboardInterrupt` → `interrupted`, graceful Ctrl+C / timeout (which exit normally via the stop flags) → `interrupted`, else `completed`.
- **Log pointers**: driver log path explicitly; per-node log path as `graph_dir/<node>/output.log` with node names listed for small graphs (≤6) or just a count otherwise (scales to many nodes).
- **Timing**: start/end wall-clock and elapsed runtime, measured from the top of `launch_mode` through teardown.
- **Ray cluster**: alive node count + CPU/GPU/memory, re-queried at summary time (no-op if Ray is already down).
- **Simulations**: cumulative total ever stored (`total_length`) alongside the current live buffer counts; falls back to the plain `Buffer:` line if that field is unavailable.
- All best-effort blocks are wrapped in try/except so a failure degrades to fewer summary lines, never a crashed run.

## Testing

Ran `examples/01_minimal` with `--no-interactive`; the summary block appears both on the terminal and in `graph_dir/driver/output.log`. (The timestamp/runtime/Ray/total-sims lines were added after that run and verified only via `ast.parse` + the try/except guards; a fresh end-to-end run is recommended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)