### PR TITLE
Fix stale docs and update FALCON acronym expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/cweniger/falcon/branch/main/graph/badge.svg)](https://codecov.io/gh/cweniger/falcon)
 [![Documentation](https://img.shields.io/badge/docs-cweniger.github.io%2Ffalcon-blue)](https://cweniger.github.io/falcon/)
 
-Falcon (Factorized adaptive learning of conditional networks) is a CLI-driven Python framework for **simulation-based inference (SBI)** with large, expensive simulators. Born in astrophysics, built for any domain with complex forward models — break your model into components and Falcon jointly infers their parameters.
+Falcon (Factorized Adaptive Learning of Conditional Orchestrated Networks) is a CLI-driven Python framework for **simulation-based inference (SBI)** with large, expensive simulators. Born in astrophysics, built for any domain with complex forward models — break your model into components and Falcon jointly infers their parameters.
 
 - **Composable** — define multi-component models as a graph of simulators in YAML, each wrapped with a thin Python interface, regardless of framework.
 - **Adaptive** — steers simulations toward high-posterior regions as training progresses, focusing compute where it matters.

--- a/docs/api/flow.md
+++ b/docs/api/flow.md
@@ -134,6 +134,11 @@ Controls posterior sampling and amortization.
 | `log_ratio_threshold` | float | -20 | Log-likelihood threshold for sample discarding |
 | `sample_reference_posterior` | bool | false | Sample from reference posterior |
 | `use_best_models_during_inference` | bool | true | Use best validation model for sampling |
+| `num_proposals` | int | 256 | Candidate samples drawn from the flow for importance sampling |
+| `reference_samples` | int | 128 | Samples used to evaluate the reference posterior |
+| `hypercube_bound` | float | 2.0 | Out-of-bounds threshold in hypercube space |
+| `out_of_bounds_penalty` | float | 100.0 | Log-weight penalty applied to out-of-bounds proposals |
+| `nan_replacement` | float | -100.0 | Log-weight substituted for NaN values during importance sampling |
 
 ```yaml
 inference:

--- a/docs/api/gaussian.md
+++ b/docs/api/gaussian.md
@@ -57,7 +57,7 @@ estimator:
 |-----------|------|---------|-------------|
 | `hidden_dim` | int | 128 | MLP hidden layer dimension |
 | `num_layers` | int | 3 | Number of hidden layers |
-| `momentum` | float | 0.10 | EMA momentum for running statistics |
+| `momentum` | float | 0.01 | EMA momentum for running statistics |
 | `min_var` | float | 1e-20 | Minimum variance for numerical stability |
 | `eig_update_freq` | int | 1 | Eigendecomposition update frequency |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,18 +31,18 @@ Configure file paths:
 
 ```yaml
 paths:
-  import_path: "."
-  buffer_dir: "sim_dir"
-  graph_dir: "graph_dir"
-  samples_dir: "samples_dir"
+  import: "."
+  buffer: ${run_dir}/sim_dir
+  graph: ${run_dir}/graph_dir
+  samples: ${run_dir}/samples_dir
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `import_path` | str | `"."` | Path to import custom modules |
-| `buffer_dir` | str | `"sim_dir"` | Simulation buffer directory |
-| `graph_dir` | str | `"graph_dir"` | Trained models directory |
-| `samples_dir` | str | `"samples_dir"` | Output samples directory |
+| `import` | str | `"."` | Path to import custom modules |
+| `buffer` | str | `${run_dir}/sim_dir` | Simulation buffer directory |
+| `graph` | str | `${run_dir}/graph_dir` | Trained models directory |
+| `samples` | str | `${run_dir}/samples_dir` | Output samples directory |
 
 ### `buffer`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,8 +37,7 @@ import numpy as np
 class Simulator:
     """Simple Gaussian simulator."""
 
-    def sample(self, batch_dim, parent_conditions=[]):
-        theta = parent_conditions[0]  # Parameters from parent node
+    def simulate_batch(self, batch_size, theta):
         noise = np.random.randn(*theta.shape) * 0.1
         return theta + noise
 ```
@@ -55,7 +54,7 @@ logging:
     enabled: true
 
 paths:
-  import_path: "."
+  import: "."
 
 buffer:
   min_samples: 1000

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Falcon
 
-**A Python framework for simulation-based inference with adaptive learning.**
+**Factorized Adaptive Learning of Conditional Orchestrated Networks**
 
-Falcon enables adaptive learning of complex conditional distributions through a declarative YAML-based approach. Built on PyTorch, Ray, and the sbi library, it provides automatic parallelization and experiment tracking.
+Falcon is a Python framework for simulation-based inference (SBI) with adaptive learning. It enables learning of complex conditional distributions through a declarative YAML-based approach, with distributed network training orchestrated via Ray.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

- Fix `paths` config key names in docs (`import_path`/`buffer_dir` etc. → `import`/`buffer`/`graph`/`samples`)
- Fix simulator method name in getting-started guide (`sample()` → `simulate_batch()`)
- Fix `Gaussian` estimator `momentum` default in docs (`0.10` → `0.01`)
- Document 5 missing `Flow` `InferenceConfig` fields: `num_proposals`, `reference_samples`, `hypercube_bound`, `out_of_bounds_penalty`, `nan_replacement`
- Update FALCON acronym to **Factorized Adaptive Learning of Conditional Orchestrated Networks** in `README.md` and `docs/index.md`

## Test plan

- [ ] Verify docs build locally with `mkdocs serve`
- [ ] Merging to `main` will trigger the `docs.yml` workflow and redeploy GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)