### PR TITLE
Warn on GPU over-subscription and timeout actor init to prevent silent hang

### DIFF
--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -583,24 +583,7 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
     ### Run analysis ###
     ####################
 
-    # 1) Deploy graph (pass logging config)
-    deployed_graph = falcon.DeployedGraph(
-        graph,
-        model_path=cfg.paths.get("import"),
-        log_config=logging_cfg,
-    )
-
-    # 2) Prepare dataset manager for deployed graph and store initial samples
-    from omegaconf import OmegaConf
-    from falcon.core.raystore import BufferConfig
-    buffer_cfg = OmegaConf.merge(OmegaConf.structured(BufferConfig), cfg.buffer)
-    dataset_manager = falcon.get_ray_dataset_manager(
-        buffer_cfg,
-        samples_path=cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir"),
-        log_config=logging_cfg,
-    )
-
-    # 3) Start status polling thread for interactive mode
+    # Start status polling thread for interactive mode
     status_thread = None
     graph_path = Path(cfg.paths.graph)
     if display:
@@ -647,7 +630,6 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
         status_thread = threading.Thread(target=poll_status, daemon=True)
         status_thread.start()
 
-    # 4) Launch training & simulations
     # Create stop check callback for graceful shutdown (handles Ctrl+C and timeout)
     _start_time = _time.time()
     _timeout_logged = False
@@ -670,7 +652,25 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
         return False
 
     run_status = "completed"
+    deployed_graph = None
     try:
+        # 1) Deploy graph (pass logging config)
+        deployed_graph = falcon.DeployedGraph(
+            graph,
+            model_path=cfg.paths.get("import"),
+            log_config=logging_cfg,
+        )
+
+        # 2) Prepare dataset manager for deployed graph and store initial samples
+        from omegaconf import OmegaConf as _OmegaConf
+        from falcon.core.raystore import BufferConfig as _BufferConfig
+        buffer_cfg = _OmegaConf.merge(_OmegaConf.structured(_BufferConfig), cfg.buffer)
+        dataset_manager = falcon.get_ray_dataset_manager(
+            buffer_cfg,
+            samples_path=cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir"),
+            log_config=logging_cfg,
+        )
+
         deployed_graph.launch(dataset_manager, observations, graph_path=graph_path, stop_check=stop_check)
 
         #############################
@@ -737,7 +737,8 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
         if shutdown_handler:
             shutdown_handler.uninstall()
 
-        deployed_graph.shutdown()
+        if deployed_graph is not None:
+            deployed_graph.shutdown()
         driver_logger.shutdown()
 
 

--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -486,9 +486,43 @@ class DeployedGraph:
             warning(f"Could not create monitor bridge: {e}")
             self.monitor_bridge = None
 
+    def _check_resource_budget(self):
+        """Raise if node GPU/CPU requests exceed cluster capacity."""
+        cluster = ray.cluster_resources()
+        available_gpus = cluster.get("GPU", 0)
+        available_cpus = cluster.get("CPU", 0)
+
+        total_gpus = sum(
+            node.actor_config.get("num_gpus", 0) * node.num_actors
+            for node in self.graph.node_list
+        )
+        total_cpus = sum(
+            node.actor_config.get("num_cpus", 1) * node.num_actors
+            for node in self.graph.node_list
+        )
+
+        if total_gpus > available_gpus:
+            node_summary = ", ".join(
+                f"{n.name}: {n.actor_config.get('num_gpus', 0)} GPU"
+                for n in self.graph.node_list
+                if n.actor_config.get("num_gpus", 0) > 0
+            )
+            warning(
+                f"GPU over-subscription: nodes request {total_gpus:.1f} GPUs "
+                f"but only {available_gpus:.1f} available. "
+                f"Actors may hang — reduce ray.num_gpus in your config or increase "
+                f"available GPUs. ({node_summary})"
+            )
+        if total_cpus > available_cpus:
+            warning(
+                f"CPU over-subscription: nodes request {total_cpus} CPUs "
+                f"but only {available_cpus:.0f} available — actors may queue."
+            )
+
     def deploy_nodes(self):
         """Deploy all nodes in the graph as Ray actors."""
         info("Spinning up graph...")
+        self._check_resource_budget()
 
         # Create all actors (non-blocking)
         for node in self.graph.node_list:
@@ -511,9 +545,18 @@ class DeployedGraph:
             try:
                 # MultiplexNodeWrapper has wait_ready(), NodeWrapper uses __ray_ready__
                 if hasattr(actor, 'wait_ready'):
-                    ray.get(actor.wait_ready.remote())
+                    ready_ref = actor.wait_ready.remote()
                 else:
-                    ray.get(actor.__ray_ready__.remote())
+                    ready_ref = actor.__ray_ready__.remote()
+                done, _ = ray.wait([ready_ref], timeout=60.0)
+                if not done:
+                    raise RuntimeError(
+                        f"Node '{name}' did not initialize within 60 s. "
+                        "This usually means Ray cannot schedule the actor — "
+                        "check that ray.num_gpus/num_cpus in your config do not "
+                        "exceed available cluster resources."
+                    )
+                ray.get(done[0])  # re-raise any actor-side exception
                 info(f"  ✓ {name}")
 
                 # Register node with monitor bridge


### PR DESCRIPTION
## Summary

Fixes #43.

- Adds a pre-flight `_check_resource_budget()` check that warns when the sum of `ray.num_gpus` (or `num_cpus`) across all nodes exceeds cluster capacity, including remediation advice (reduce `ray.num_gpus` or increase available GPUs).
- Replaces the bare `ray.get()` in `deploy_nodes()` with a 60-second `ray.wait()` timeout; if an actor fails to come up in time, a `RuntimeError` is raised with a clear message pointing to the resource config as the likely cause.

## Test plan

- [ ] Run with GPU over-subscribed config (e.g. total `num_gpus > 1` on a 1-GPU machine) and confirm the pre-flight warning is printed before actors are created.
- [ ] Confirm the 60-second timeout raises a `RuntimeError` with a helpful message when an actor cannot be scheduled.
- [ ] Run a normal (non-over-subscribed) config end-to-end and confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)