### PR TITLE
Fix stale TrainingLoopConfig module path in API docs

### DIFF
--- a/docs/api/flow.md
+++ b/docs/api/flow.md
@@ -344,4 +344,4 @@ Flow logs the following metrics during training:
 
 ::: falcon.estimators.flow.InferenceConfig
 
-::: falcon.estimators.base.TrainingLoopConfig
+::: falcon.estimators.stepwise_base.TrainingLoopConfig


### PR DESCRIPTION
## Summary

- `TrainingLoopConfig` was moved from `falcon.estimators.base` to `falcon.estimators.stepwise_base` in the PR #54 refactor
- The `:::` reference in `docs/api/flow.md` was not updated, causing the **Deploy docs** CI job to fail on every push to main since PR #54
- One-line fix: update the module path to `falcon.estimators.stepwise_base.TrainingLoopConfig`

## Test plan

- [ ] Verify the **Deploy docs** CI job passes on this branch
- [ ] Confirm `TrainingLoopConfig` renders correctly in the Flow API docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)