### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "falcon-sbi"
-version = "0.3.0"
+version = "0.4.0"
 description = "CLI-driven framework for simulation-based inference with large simulators"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Bumps `pyproject.toml` version from `0.3.0` to `0.4.0` ahead of the v0.4.0 release.