### PR TITLE
Make blessed and textual soft optional; drop unused rich

### DIFF
--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -497,7 +497,7 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
             display = InteractiveDisplay(footer_height=log_lines + 4)
             display.start()
         except ImportError:
-            print("Install blessed to get a blessed experience: pip install blessed")
+            print("Interactive display unavailable (pip install blessed to enable it)")
     if display is None:
         # Non-interactive mode: install double Ctrl+C handler
         shutdown_handler = _GracefulShutdown()

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -491,11 +491,14 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
     display = None
     shutdown_handler = None
     if interactive:
-        from falcon.interactive import InteractiveDisplay
-        # Footer height = log_lines + 4 (separator, status bar, sub-separator, help)
-        display = InteractiveDisplay(footer_height=log_lines + 4)
-        display.start()
-    else:
+        try:
+            from falcon.interactive import InteractiveDisplay
+            # Footer height = log_lines + 4 (separator, status bar, sub-separator, help)
+            display = InteractiveDisplay(footer_height=log_lines + 4)
+            display.start()
+        except ImportError:
+            print("Install blessed to get a blessed experience: pip install blessed")
+    if display is None:
         # Non-interactive mode: install double Ctrl+C handler
         shutdown_handler = _GracefulShutdown()
         shutdown_handler.install()
@@ -836,7 +839,11 @@ def sample_mode(cfg, sample_type: str) -> None:
 
 def monitor_mode(address: str = "auto", refresh: float = 1.0):
     """Monitor mode: Launch the TUI monitor directly (no subprocess)."""
-    from falcon.monitor import init_ray_for_monitor, FalconMonitor
+    try:
+        from falcon.monitor import init_ray_for_monitor, FalconMonitor
+    except ImportError:
+        print("falcon monitor requires textual. Install with: pip install 'falcon-sbi[monitor]'")
+        sys.exit(1)
     if not init_ray_for_monitor(address):
         sys.exit(1)
     app = FalconMonitor(ray_address=address, refresh_interval=refresh)

--- a/falcon/interactive.py
+++ b/falcon/interactive.py
@@ -1,7 +1,7 @@
 """Interactive TUI for falcon launch.
 
 Provides a scrolling log view with a fixed status footer showing node log tails.
-Uses Blessed for terminal control and Rich for formatting.
+Uses Blessed for terminal control (optional — install with: pip install blessed).
 """
 
 import atexit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,6 @@ dependencies = [
     "ray>=2.0",
     "omegaconf>=2.1",
     "coolname>=1.0",
-    "rich>=13.0",
-    "blessed>=1.20",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- **Remove `blessed` from core deps** — it's only ever imported when `sys.stdout.isatty()` is `True`, so Colab users (where it's always `False`) were getting a `wcwidth` version conflict and a runtime-restart warning on every `pip install falcon-sbi` for no reason. `falcon launch` now falls back gracefully to non-interactive mode with the message: *Interactive display unavailable (pip install blessed to enable it)*
- **Remove `rich` from core deps** — declared as a dependency but never imported anywhere in the codebase; dead weight
- **Graceful error for `textual`** — `falcon monitor` already required the `[monitor]` extra, but a missing install produced a cryptic `ImportError`; now prints a clear install hint and exits cleanly

## Test plan

- [ ] `pip install falcon-sbi` in a fresh Colab notebook — no wcwidth conflict, no restart warning
- [ ] `falcon launch` in a TTY without `blessed` installed — falls back to non-interactive mode, prints message
- [ ] `falcon launch` in a TTY with `blessed` installed — interactive TUI works as before
- [ ] `falcon monitor` without `textual` installed — prints install hint, exits 1
- [ ] `falcon monitor` with `textual` installed — works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)