### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -497,7 +497,7 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
             display = InteractiveDisplay(footer_height=log_lines + 4)
             display.start()
         except ImportError:
-            print("Interactive display unavailable (pip install blessed to enable it)")
+            print("Interactive display unavailable (install falcon-sbi[blessed] to enable it)")
     if display is None:
         # Non-interactive mode: install double Ctrl+C handler
         shutdown_handler = _GracefulShutdown()
@@ -842,7 +842,7 @@ def monitor_mode(address: str = "auto", refresh: float = 1.0):
     try:
         from falcon.monitor import init_ray_for_monitor, FalconMonitor
     except ImportError:
-        print("falcon monitor requires textual. Install with: pip install 'falcon-sbi[monitor]'")
+        print("falcon monitor requires falcon-sbi[monitor]")
         sys.exit(1)
     if not init_ray_for_monitor(address):
         sys.exit(1)

--- a/falcon/core/wandb_logger.py
+++ b/falcon/core/wandb_logger.py
@@ -1,7 +1,7 @@
 """
 WandB logging backend.
 
-Logs metrics to Weights & Biases. Optional dependency - install with: pip install falcon-sbi[wandb]
+Logs metrics to Weights & Biases. Optional dependency: falcon-sbi[wandb]
 """
 
 import logging
@@ -22,8 +22,7 @@ def _check_wandb_available():
     """Raise ImportError if wandb is not installed."""
     if not WANDB_AVAILABLE:
         raise ImportError(
-            "wandb is required for WandB logging.\n"
-            "Install it with: pip install falcon-sbi[wandb]"
+            "wandb is required for WandB logging (falcon-sbi[wandb])"
         )
 
 

--- a/falcon/estimators/flow_density.py
+++ b/falcon/estimators/flow_density.py
@@ -16,7 +16,7 @@ def _get_net_builders():
         from sbi.neural_nets import net_builders
     except ImportError:
         raise ImportError(
-            "sbi is required for flow-based estimators (falcon-sbi[sbi])"
+            "python module sbi is required for flow-based estimators (falcon-sbi[sbi])"
         )
     return {
         "nsf": net_builders.build_nsf,

--- a/falcon/estimators/flow_density.py
+++ b/falcon/estimators/flow_density.py
@@ -1,6 +1,6 @@
 """Flow networks for density estimation.
 
-Requires the sbi package: pip install falcon-sbi[sbi]
+Requires the sbi package: falcon-sbi[sbi]
 """
 
 import numpy as np
@@ -16,8 +16,7 @@ def _get_net_builders():
         from sbi.neural_nets import net_builders
     except ImportError:
         raise ImportError(
-            "sbi is required for flow-based estimators.\n"
-            "Install it with: pip install falcon-sbi[sbi]"
+            "sbi is required for flow-based estimators (falcon-sbi[sbi])"
         )
     return {
         "nsf": net_builders.build_nsf,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "falcon-sbi"
-version = "0.4.0"
+version = "0.4.1"
 description = "CLI-driven framework for simulation-based inference with large simulators"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
 sbi = ["sbi>=0.18"]
 wandb = ["wandb>=0.15.0"]
 monitor = ["textual>=0.40.0"]
-all = ["sbi>=0.18", "wandb>=0.15.0", "textual>=0.40.0"]
+blessed = ["blessed>=1.20"]
+all = ["sbi>=0.18", "wandb>=0.15.0", "textual>=0.40.0", "blessed>=1.20"]
 docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.0",


### PR DESCRIPTION
Version bump for the v0.4.1 bugfix release. Also includes follow-on cleanup that belongs in the same release:

- Add `blessed` optional extra (`falcon-sbi[blessed]`)
- Remove `pip install` from all install hints across the codebase — hints now just reference the extra name (e.g. `falcon-sbi[sbi]`, `falcon-sbi[wandb]`) so they work regardless of the user's package manager
- Clarify sbi error message to avoid confusion with the `falcon-sbi` package name

🤖 Generated with [Claude Code](https://claude.com/claude-code)