### PR TITLE
Rename output directories, remove dead paths.buffer config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,15 +131,18 @@ graph:
 
 ```
 {run_dir}/
-├── sim_dir/                    # Simulation buffer (samples_*.pt)
-├── graph_dir/                  # Trained models and logs
+├── graph/                      # Trained models and logs
 │   ├── graph.pkl               # Serialized graph structure
 │   ├── {node_name}/            # Per-node directories
 │   │   └── estimator.pt        # Network weights
 │   ├── output.log              # Training logs
 │   └── metrics/                # Metric history (chunk_*.npz)
-├── samples_dir/                # Generated samples
-│   └── posterior/{timestamp}/  # Timestamped sample batches
+├── samples/                    # Generated samples
+│   └── posterior/              # Posterior sample files
+│       ├── 000000.npz
+│       └── 000001.npz
+├── buffer/
+│   └── snapshots/              # Buffer snapshots (when store_fraction > 0)
 │       └── 000000.npz
 └── config.yml                 # Saved configuration
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,17 +32,15 @@ Configure file paths:
 ```yaml
 paths:
   import: "."
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 ```
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `import` | str | `"."` | Path to import custom modules |
-| `buffer` | str | `${run_dir}/sim_dir` | Simulation buffer directory |
-| `graph` | str | `${run_dir}/graph_dir` | Trained models directory |
-| `samples` | str | `${run_dir}/samples_dir` | Output samples directory |
+| `graph` | str | `${run_dir}/graph` | Trained models directory |
+| `samples` | str | `${run_dir}/samples` | Output samples directory |
 
 ### `buffer`
 
@@ -67,7 +65,7 @@ buffer:
 | `simulate_count` | int | `64` | Number of new samples generated per simulation round. For simulators taking >1s per sample, keep this small (4–16) to avoid long delays between buffer updates; for fast simulators, increase to reduce Ray overhead. |
 | `simulate_interval` | float | `1` | Seconds between simulation rounds |
 | `simulate_when_full` | bool | `true` | If `true`, simulation continues after `max_samples` is reached and old samples are replaced; if `false`, simulation stops once the buffer is full |
-| `store_fraction` | float | `0.0` | Fraction of simulated samples written to `samples_dir/buffer/` for inspection (0 = none, 1 = all) |
+| `store_fraction` | float | `0.0` | Fraction of simulated samples written to `buffer/snapshots/` for inspection (0 = none, 1 = all) |
 
 ### `graph`
 

--- a/examples/01_minimal/config.yml
+++ b/examples/01_minimal/config.yml
@@ -23,7 +23,7 @@
 # Notes:
 #   • All outputs (simulations, trained models, logs) are written under
 #     ${run_dir}, which is set via --output or auto-generated.
-#   • ${run_dir} is referenced by buffer, graph, and WandB logging paths.
+#   • ${run_dir} is referenced by graph, samples, and WandB logging paths.
 #   • Resuming: specify existing --output to load saved config.yaml
 # =============================================================================
 
@@ -45,9 +45,8 @@ logging:
 # -----------------------------------------------------------------------------
 paths:
   import: "./src"                       # Local folder(s) with user-defined code (e.g. model.py)
-  buffer: ${run_dir}/sim_dir            # Directory where Falcon stores simulated training data
-  graph: ${run_dir}/graph_dir           # Directory for serialized graph and trained networks
-  samples: ${run_dir}/samples_dir       # Directory for generated samples (posterior, prior, etc.)
+  graph: ${run_dir}/graph               # Directory for serialized graph and trained networks
+  samples: ${run_dir}/samples           # Directory for generated samples (posterior, prior, etc.)
 
 # -----------------------------------------------------------------------------
 # Training buffer parameters
@@ -59,7 +58,7 @@ buffer:
   simulate_count: 64                    # Number of new samples generated per simulation round
   simulate_when_full: true              # If true, keep simulating when buffer is full (old samples disfavoured); if false, stop at max_samples
   simulate_interval: 1                  # Seconds between simulation rounds
-  store_fraction: 0.1                   # Fraction of samples to dump to samples_dir/buffer/ (0=none, 1=all)
+  store_fraction: 0.1                   # Fraction of samples to dump to buffer/snapshots/ (0=none, 1=all)
 
 # -----------------------------------------------------------------------------
 # Graph definition using declarative YAML

--- a/examples/02_bimodal/config_amortized.yml
+++ b/examples/02_bimodal/config_amortized.yml
@@ -12,9 +12,8 @@ logging:
 # Directory configuration
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # Training buffer parameters
 buffer:

--- a/examples/02_bimodal/config_regular.yml
+++ b/examples/02_bimodal/config_regular.yml
@@ -12,9 +12,8 @@ logging:
 # Directory configuration
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # Training buffer parameters
 buffer:

--- a/examples/02_bimodal/config_rounds_fill.yml
+++ b/examples/02_bimodal/config_rounds_fill.yml
@@ -12,9 +12,8 @@ logging:
 # Directory configuration
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # Training buffer parameters
 buffer:

--- a/examples/02_bimodal/config_rounds_renew.yml
+++ b/examples/02_bimodal/config_rounds_renew.yml
@@ -12,9 +12,8 @@ logging:
 # Directory configuration
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # Training buffer parameters
 buffer:

--- a/examples/03_composite/config.yml
+++ b/examples/03_composite/config.yml
@@ -12,9 +12,8 @@ logging:
 # Directory configuration
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # Training buffer parameters
 buffer:

--- a/examples/04_gaussian/config.yml
+++ b/examples/04_gaussian/config.yml
@@ -38,9 +38,8 @@ logging:
 # -----------------------------------------------------------------------------
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # -----------------------------------------------------------------------------
 # Training buffer parameters

--- a/examples/04_gaussian/run_example.py
+++ b/examples/04_gaussian/run_example.py
@@ -133,7 +133,7 @@ def main():
         sys.exit(1)
 
     # Step 3: Analyze samples
-    samples_dir = run_dir / "samples_dir"
+    samples_dir = run_dir / "samples"
     analyze_samples(samples_dir)
 
 

--- a/examples/05_linear_regression/config.yml
+++ b/examples/05_linear_regression/config.yml
@@ -39,9 +39,8 @@ logging:
 # -----------------------------------------------------------------------------
 paths:
   import: "./src"
-  buffer: ${run_dir}/sim_dir
-  graph: ${run_dir}/graph_dir
-  samples: ${run_dir}/samples_dir
+  graph: ${run_dir}/graph
+  samples: ${run_dir}/samples
 
 # -----------------------------------------------------------------------------
 # Training buffer parameters

--- a/examples/05_linear_regression/run_example.py
+++ b/examples/05_linear_regression/run_example.py
@@ -139,7 +139,7 @@ def main():
         sys.exit(1)
 
     # Step 3: Analyze samples
-    samples_dir = run_dir / "samples_dir"
+    samples_dir = run_dir / "samples"
     analyze_samples(samples_dir, script_dir)
 
 

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -318,7 +318,7 @@ def _build_run_summary(status, output_dir, cfg, deployed_graph, start_time=None,
     lines.append("=" * 60)
     lines.append(f"falcon launch {status}")
     lines.append(f"Output:  {output_dir}")
-    samples_path = cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir")
+    samples_path = cfg.paths.get("samples", f"{cfg.run_dir}/samples")
     lines.append(f"Samples: {samples_path}")
     graph_path = Path(cfg.paths.graph)
     lines.append(f"Logs:    {graph_path / 'driver' / 'output.log'}  (driver)")
@@ -453,7 +453,7 @@ def _save_samples(samples, sample_cfg, sample_type, graph, cfg, info_fn=print):
         info_fn(f"  {key}: {value.shape}")
 
     # Determine output directory (flat structure)
-    samples_dir = cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir")
+    samples_dir = cfg.paths.get("samples", f"{cfg.run_dir}/samples")
     output_dir = Path(samples_dir) / sample_type
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -670,7 +670,7 @@ def launch_mode(cfg, interactive: bool = False, log_lines: int = 16, posterior_s
         buffer_cfg = _OmegaConf.merge(_OmegaConf.structured(_BufferConfig), cfg.buffer)
         dataset_manager = falcon.get_ray_dataset_manager(
             buffer_cfg,
-            samples_path=cfg.paths.get("samples", f"{cfg.run_dir}/samples_dir"),
+            snapshots_path=str(Path(cfg.run_dir) / "buffer" / "snapshots"),
             log_config=logging_cfg,
         )
 

--- a/falcon/core/raystore.py
+++ b/falcon/core/raystore.py
@@ -137,9 +137,9 @@ class DatasetManagerActor:
         simulate_chunk_size,
         initial_samples_path,
         simulate_when_full,
-        samples_path,
         store_fraction,
         log_config=None,
+        snapshots_path=None,
     ):
         self.max_samples = max_samples
         self.min_samples = min_samples
@@ -149,7 +149,7 @@ class DatasetManagerActor:
         self.simulate_interval = simulate_interval
         self.simulate_chunk_size = simulate_chunk_size
         self.initial_samples_path = initial_samples_path
-        self.samples_path = Path(samples_path) if samples_path else None
+        self.snapshots_path = Path(snapshots_path) if snapshots_path else None
         self.store_fraction = store_fraction
 
         # NPZ storage state
@@ -363,7 +363,7 @@ class DatasetManagerActor:
         info(f"Appended {num_new_samples} samples | total={total_after} train={n_train} val={n_val}")
 
         # Disk dump: fetch values lazily if needed
-        if self.store_fraction > 0 and self.samples_path is not None:
+        if self.store_fraction > 0 and self.snapshots_path is not None:
             self._dump_refs(sample_refs)
 
     def _dump_refs(self, sample_refs: list):
@@ -377,14 +377,11 @@ class DatasetManagerActor:
                 self._save_sample(sample)
 
     def _save_sample(self, sample: dict):
-        """Save a single sample as NPZ file to samples_path/buffer/."""
-        buffer_dir = self.samples_path / "buffer"
-        buffer_dir.mkdir(parents=True, exist_ok=True)
-
-        # Find next index from existing files
-        existing = sorted(buffer_dir.glob("*.npz"))
+        """Save a single sample as NPZ file to buffer/snapshots/."""
+        self.snapshots_path.mkdir(parents=True, exist_ok=True)
+        existing = sorted(self.snapshots_path.glob("*.npz"))
         next_idx = len(existing)
-        sample_path = buffer_dir / f"{next_idx:06d}.npz"
+        sample_path = self.snapshots_path / f"{next_idx:06d}.npz"
         np.savez(sample_path, **sample)
 
     def dump_store(self, samples: list):
@@ -393,7 +390,7 @@ class DatasetManagerActor:
         Args:
             samples: List of sample dicts to potentially store
         """
-        if self.store_fraction <= 0 or self.samples_path is None:
+        if self.store_fraction <= 0 or self.snapshots_path is None:
             return
 
         interval = max(1, int(1.0 / self.store_fraction))
@@ -424,7 +421,7 @@ class DatasetManagerActor:
         """Load pre-existing samples from NPZ sample directory. Returns number loaded.
 
         Expects initial_samples_path to point to a sample type directory
-        (e.g. samples_dir/prior) as produced by ``falcon sample prior``.
+        (e.g. samples/prior) as produced by ``falcon sample prior``.
         NPZ keys are remapped: ``key`` -> ``key.value`` with ``key.log_prob = 0.0``.
         """
         if self.initial_samples_path is not None:
@@ -674,14 +671,14 @@ class BufferView:
 
 def get_ray_dataset_manager(
     config: BufferConfig,
-    samples_path=None,
+    snapshots_path=None,
     log_config=None,
 ):
     from omegaconf import OmegaConf
     cfg = OmegaConf.to_container(config, resolve=True) if not isinstance(config, dict) else config
     dataset_manager_actor = DatasetManagerActor.remote(
         **cfg,
-        samples_path=samples_path,
+        snapshots_path=snapshots_path,
         log_config=log_config,
     )
     return DatasetManager(dataset_manager_actor)

--- a/falcon/core/run_loader.py
+++ b/falcon/core/run_loader.py
@@ -57,7 +57,7 @@ class Run:
     def samples(self) -> SamplesReader:
         """Access samples (posterior, prior, proposal)."""
         if self._samples is None:
-            samples_dir = self.run_dir / "samples_dir"
+            samples_dir = self.run_dir / "samples"
             self._samples = SamplesReader(samples_dir)
         return self._samples
 
@@ -65,7 +65,7 @@ class Run:
     def buffer(self) -> SampleSetReader:
         """Access training buffer samples stored during training.
 
-        Returns a SampleSetReader for the sim_dir (paths.buffer).
+        Returns a SampleSetReader for buffer/snapshots.
         Samples are stored when buffer.store_fraction > 0.
 
         Usage:
@@ -74,7 +74,7 @@ class Run:
             run.buffer.stacked['z'] # Stacked array
         """
         if self._buffer is None:
-            buffer_dir = self.run_dir / "sim_dir"
+            buffer_dir = self.run_dir / "buffer" / "snapshots"
             self._buffer = SampleSetReader(buffer_dir)
         return self._buffer
 
@@ -82,7 +82,7 @@ class Run:
     def metrics(self) -> RunReader:
         """Access training metrics."""
         if self._metrics is None:
-            graph_dir = self.run_dir / "graph_dir"
+            graph_dir = self.run_dir / "graph"
             self._metrics = RunReader(graph_dir)
         return self._metrics
 

--- a/falcon/core/samples_reader.py
+++ b/falcon/core/samples_reader.py
@@ -4,7 +4,7 @@ Samples reader for loading posterior/prior/proposal samples.
 Provides lazy-loaded access to samples stored as individual NPZ files.
 
 Usage:
-    samples = read_samples('outputs/run_01/samples_dir')
+    samples = read_samples('outputs/run_01/samples')
 
     # Access by sample type
     samples.posterior              # SampleSetReader
@@ -153,7 +153,7 @@ class SamplesReader:
     """Top-level reader for all sample types in a samples directory.
 
     Usage:
-        samples = read_samples('outputs/run_01/samples_dir')
+        samples = read_samples('outputs/run_01/samples')
         samples.posterior['x']  # Access posterior samples
         samples.types           # ['posterior', 'prior', ...]
     """
@@ -193,13 +193,13 @@ def read_samples(path: str) -> SamplesReader:
     """Read samples from a samples directory.
 
     Args:
-        path: Path to the samples directory (e.g., 'outputs/run_01/samples_dir')
+        path: Path to the samples directory (e.g., 'outputs/run_01/samples')
 
     Returns:
         SamplesReader providing access to all sample types.
 
     Example:
-        samples = read_samples('outputs/run_01/samples_dir')
+        samples = read_samples('outputs/run_01/samples')
         samples.posterior[32]           # Dict for sample 32
         samples.posterior['x']          # List of arrays
         samples.posterior.stacked['x']  # Stacked array

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -89,8 +89,8 @@ def test_example_runs_without_error(example_name, config_name, epoch_overrides, 
     )
 
     # Verify output.log files were created by the logging system
-    graph_dir = tmp_path / "graph_dir"
-    assert graph_dir.exists(), f"graph_dir not found at {graph_dir}"
+    graph_dir = tmp_path / "graph"
+    assert graph_dir.exists(), f"graph dir not found at {graph_dir}"
 
     # Check driver output.log exists
     driver_log = graph_dir / "driver" / "output.log"


### PR DESCRIPTION
## Summary

- **Remove `paths.buffer` / `sim_dir`**: this config key was never read by the CLI and the directory was never created — the buffer has always been in-memory
- **`graph_dir` → `graph`**, **`samples_dir` → `samples`**: drop the redundant `_dir` suffix
- **`samples_dir/buffer/` → `buffer/snapshots/`**: buffer snapshots (written when `store_fraction > 0`) are internal training diagnostics, not user-facing samples — moving them out of `samples/` clarifies the distinction
- **Fix `CLAUDE.md` output structure**: remove phantom `{timestamp}` subdirectory under `posterior/` (never existed in code)

New output tree:
```
{run_dir}/
├── graph/
├── samples/
│   └── posterior/000000.npz ...
├── buffer/
│   └── snapshots/000000.npz ...   (only when store_fraction > 0)
└── config.yml
```

## Test plan

- [ ] `falcon launch` creates `graph/` and `samples/` (not `graph_dir/` / `samples_dir/`)
- [ ] `falcon sample posterior` writes to `samples/posterior/`
- [ ] `store_fraction > 0` writes to `buffer/snapshots/`
- [ ] `run.metrics`, `run.samples`, `run.buffer` in `run_loader` resolve correctly
- [ ] Smoke tests pass (`tests/test_examples_smoke.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)