### PR TITLE
Add prior_epochs warmup to estimators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ pip install .
 # Training
 falcon launch                                    # Run with default config
 falcon launch -o outputs/exp01                   # Specify output directory
-falcon launch buffer.num_epochs=500              # Override config parameters
+falcon launch buffer.max_epochs=500              # Override config parameters
 falcon launch -c config_amortized                # Use alternate config file
 
 # Sampling (after training)
@@ -98,7 +98,7 @@ graph:
     estimator:                    # Posterior network
       _target_: falcon.estimators.Flow
       loop:                       # Training loop config
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
       network:                    # Network config
         net_type: nsf

--- a/docs/api/flow.md
+++ b/docs/api/flow.md
@@ -48,7 +48,7 @@ Controls the training process.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `num_epochs` | int | 100 | Maximum training epochs |
+| `max_epochs` | int | 100 | Maximum training epochs |
 | `batch_size` | int | 128 | Training batch size |
 | `early_stop_patience` | int | 16 | Epochs without improvement before stopping |
 | `cache_sync_every` | int | 0 | Epochs between cache syncs with the buffer (0 = every epoch) |
@@ -57,7 +57,7 @@ Controls the training process.
 
 ```yaml
 loop:
-  num_epochs: 100
+  max_epochs: 100
   batch_size: 128
   early_stop_patience: 16
   cache_sync_every: 0
@@ -214,7 +214,7 @@ graph:
       _target_: falcon.estimators.Flow
 
       loop:
-        num_epochs: 100
+        max_epochs: 100
         batch_size: 128
         early_stop_patience: 16
         cache_sync_every: 0
@@ -311,7 +311,7 @@ Flow logs the following metrics during training:
 ## Tips
 
 1. **Start with defaults**: The default configuration works well for most problems
-2. **Increase `num_epochs`** for complex posteriors
+2. **Increase `max_epochs`** for complex posteriors
 3. **Enable `discard_samples`** if training becomes unstable with outliers
 4. **Use GPU** (`ray.num_gpus: 1`) for faster training with large embeddings
 5. **Lower `gamma`** for single-observation inference, higher for amortization

--- a/docs/api/gaussian.md
+++ b/docs/api/gaussian.md
@@ -27,7 +27,7 @@ Gaussian is configured through the same four groups as Flow: `loop`, `network`,
 estimator:
   _target_: falcon.estimators.Gaussian
   loop:
-    num_epochs: 1000
+    max_epochs: 1000
     batch_size: 128
     early_stop_patience: 32
   network:
@@ -81,7 +81,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Gaussian
       loop:
-        num_epochs: 1000
+        max_epochs: 1000
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ graph:
     estimator:                     # Posterior learner (optional)
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 300
+        max_epochs: 300
       network:
         net_type: nsf
       embedding:
@@ -129,7 +129,7 @@ estimator:
   _target_: falcon.estimators.Flow
 
   loop:
-    num_epochs: 300
+    max_epochs: 300
     batch_size: 128
     early_stop_patience: 50
     cache_sync_every: 0
@@ -190,5 +190,5 @@ observed: "./data/obs.npz['x']"
 Override any parameter via CLI:
 
 ```bash
-falcon launch buffer.num_epochs=1000 graph.theta.estimator.optimizer.lr=0.001
+falcon launch buffer.max_epochs=1000 graph.theta.estimator.optimizer.lr=0.001
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,7 +73,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 100
+        max_epochs: 100
       network:
         net_type: zuko_nice
 

--- a/examples/01_minimal/config.yml
+++ b/examples/01_minimal/config.yml
@@ -77,7 +77,7 @@ graph:
     estimator:                          # Posterior estimator network
       _target_: falcon.estimators.Flow   # Flow-based posterior estimation
       loop:                             # Training loop parameters
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
         early_stop_patience: 32         # Early stopping patience
       network:                          # Neural network architecture

--- a/examples/02_bimodal/config_amortized.yml
+++ b/examples/02_bimodal/config_amortized.yml
@@ -44,7 +44,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/examples/02_bimodal/config_regular.yml
+++ b/examples/02_bimodal/config_regular.yml
@@ -44,7 +44,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/examples/02_bimodal/config_rounds_fill.yml
+++ b/examples/02_bimodal/config_rounds_fill.yml
@@ -44,7 +44,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/examples/02_bimodal/config_rounds_renew.yml
+++ b/examples/02_bimodal/config_rounds_renew.yml
@@ -44,7 +44,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 600
+        max_epochs: 600
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/examples/03_composite/config.yml
+++ b/examples/03_composite/config.yml
@@ -46,7 +46,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
         early_stop_patience: 32
       network:
@@ -92,7 +92,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Flow
       loop:
-        num_epochs: 300
+        max_epochs: 300
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/examples/04_gaussian/config.yml
+++ b/examples/04_gaussian/config.yml
@@ -70,7 +70,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Gaussian
       loop:
-        num_epochs: 1000
+        max_epochs: 1000
         batch_size: 128
         early_stop_patience: 32
       network:

--- a/examples/05_linear_regression/config.yml
+++ b/examples/05_linear_regression/config.yml
@@ -79,7 +79,7 @@ graph:
     estimator:
       _target_: falcon.estimators.Gaussian
       loop:
-        num_epochs: 1000
+        max_epochs: 1000
         batch_size: 128
         early_stop_patience: 32
         cache_sync_every: 1

--- a/falcon/core/deployed_graph.py
+++ b/falcon/core/deployed_graph.py
@@ -429,7 +429,7 @@ class NodeWrapper:
                     status["loss"] = status["loss_history"][-1]
                 status["current_epoch"] = len(est.history.get("epochs", []))
             if hasattr(est, "loop_config"):
-                status["total_epochs"] = est.loop_config.num_epochs
+                status["total_epochs"] = est.loop_config.max_epochs
             if hasattr(est, "history") and est.history.get("n_samples"):
                 status["samples"] = est.history["n_samples"][-1]
 

--- a/falcon/estimators/flow.py
+++ b/falcon/estimators/flow.py
@@ -373,6 +373,8 @@ class Flow(StepwiseEstimator):
         conditions: Optional[Dict] = None,
     ) -> dict:
         """Sample from the widened proposal distribution for adaptive resampling."""
+        if self._total_epochs_trained < self.loop_config.prior_epochs:
+            return self.sample_prior(num_samples)
         # Fall back to prior if networks not yet initialized (training hasn't started)
         if not self.networks_initialized:
             return self.sample_prior(num_samples)
@@ -474,6 +476,7 @@ class Flow(StepwiseEstimator):
         torch.save(self._best_conditional_flow.state_dict(), node_dir / "conditional_flow.pth")
         torch.save(self._best_marginal_flow.state_dict(), node_dir / "marginal_flow.pth")
         torch.save(self._init_parameters, node_dir / "init_parameters.pth")
+        torch.save(self._total_epochs_trained, node_dir / "total_epochs_trained.pth")
 
         # Save history
         torch.save(self.history["train_ids"], node_dir / "train_id_history.pth")
@@ -504,6 +507,9 @@ class Flow(StepwiseEstimator):
 
         if (node_dir / "embedding.pth").exists() and self._best_embedding is not None:
             self._best_embedding.load_state_dict(torch.load(node_dir / "embedding.pth"))
+
+        _tep = node_dir / "total_epochs_trained.pth"
+        self._total_epochs_trained = torch.load(_tep) if _tep.exists() else 0
 
     # ==================== Private Helpers ====================
 

--- a/falcon/estimators/stepwise_base.py
+++ b/falcon/estimators/stepwise_base.py
@@ -22,7 +22,7 @@ from falcon.core.logger import log, debug, info, warning, error
 class TrainingLoopConfig:
     """Generic training loop parameters."""
 
-    num_epochs: int = 100
+    max_epochs: int = 100
     batch_size: int = 128
     early_stop_patience: int = 16
     cache_sync_every: int = 0  # 0 = sync every epoch, N = sync every N epochs
@@ -181,7 +181,7 @@ class StepwiseEstimator(BaseEstimator):
         total_steps = 0
         t0 = time.perf_counter()
 
-        for epoch in range(cfg.num_epochs):
+        for epoch in range(cfg.max_epochs):
             log({"epoch": self._total_epochs_trained + 1})
 
             # Periodic incremental sync
@@ -249,7 +249,7 @@ class StepwiseEstimator(BaseEstimator):
             train_loss = train_metrics_avg.get("loss", float("nan"))
             val_loss = val_metrics_avg.get("loss", float("inf"))
             summary = (
-                f"Epoch {self._total_epochs_trained + 1}/{cfg.num_epochs}"
+                f"Epoch {self._total_epochs_trained + 1}/{cfg.max_epochs}"
                 f" | steps={total_steps}"
             )
             if n_sims is not None:

--- a/falcon/estimators/stepwise_base.py
+++ b/falcon/estimators/stepwise_base.py
@@ -28,6 +28,7 @@ class TrainingLoopConfig:
     cache_sync_every: int = 0  # 0 = sync every epoch, N = sync every N epochs
     max_cache_samples: int = 0  # 0 = cache all, >0 = cache random subset
     cache_on_device: bool = False  # True = cache training data on estimator's device (GPU)
+    prior_epochs: int = 0
 
 
 class StepwiseEstimator(BaseEstimator):
@@ -70,6 +71,7 @@ class StepwiseEstimator(BaseEstimator):
         self.condition_keys = condition_keys or []
 
         self._terminated = False
+        self._total_epochs_trained: int = 0
 
         # Networks initialized flag (managed by subclass)
         self.networks_initialized = False
@@ -270,6 +272,7 @@ class StepwiseEstimator(BaseEstimator):
             self._record_epoch_history(
                 epoch, train_metrics_avg, val_metrics_avg, t0, buffer
             )
+            self._total_epochs_trained += 1
 
             if epochs_no_improve >= cfg.early_stop_patience:
                 info("Early stopping triggered.")
@@ -592,6 +595,8 @@ class LossBasedEstimator(StepwiseEstimator):
 
     def sample_proposal(self, num_samples: int, conditions: Optional[Dict] = None) -> dict:
         """Sample from widened proposal distribution for adaptive resampling."""
+        if self._total_epochs_trained < self.loop_config.prior_epochs:
+            return self.sample_prior(num_samples)
         result = self._sample(num_samples, conditions, gamma=self.inference_config.gamma)
         log({
             "sample_proposal:mean": result['value'].mean(),
@@ -615,6 +620,8 @@ class LossBasedEstimator(StepwiseEstimator):
         # Save init tensors for model rebuild
         torch.save({"theta": self._init_theta, "conditions": self._init_conditions},
                    node_dir / "init_tensors.pth")
+
+        torch.save(self._total_epochs_trained, node_dir / "total_epochs_trained.pth")
 
         # Save history
         torch.save(self.history["train_ids"], node_dir / "train_id_history.pth")
@@ -647,6 +654,9 @@ class LossBasedEstimator(StepwiseEstimator):
         )
 
         self.networks_initialized = True
+
+        _tep = node_dir / "total_epochs_trained.pth"
+        self._total_epochs_trained = torch.load(_tep) if _tep.exists() else 0
 
         # Load weights
         self._best_model.load_state_dict(torch.load(node_dir / "model.pth"))

--- a/falcon/estimators/stepwise_base.py
+++ b/falcon/estimators/stepwise_base.py
@@ -182,7 +182,7 @@ class StepwiseEstimator(BaseEstimator):
         t0 = time.perf_counter()
 
         for epoch in range(cfg.num_epochs):
-            log({"epoch": epoch + 1})
+            log({"epoch": self._total_epochs_trained + 1})
 
             # Periodic incremental sync
             if epoch > 0 and epoch % sync_every == 0:
@@ -249,7 +249,7 @@ class StepwiseEstimator(BaseEstimator):
             train_loss = train_metrics_avg.get("loss", float("nan"))
             val_loss = val_metrics_avg.get("loss", float("inf"))
             summary = (
-                f"Epoch {epoch+1}/{cfg.num_epochs}"
+                f"Epoch {self._total_epochs_trained + 1}/{cfg.num_epochs}"
                 f" | steps={total_steps}"
             )
             if n_sims is not None:
@@ -285,7 +285,7 @@ class StepwiseEstimator(BaseEstimator):
         self, epoch, train_metrics, val_metrics, t0, buffer
     ) -> None:
         """Record metrics to history dict."""
-        self.history["epochs"].append(epoch + 1)
+        self.history["epochs"].append(self._total_epochs_trained + 1)
         self.history["train_loss"].append(train_metrics.get("loss", 0))
         self.history["val_loss"].append(val_metrics.get("loss", 0))
 

--- a/tests/test_examples_smoke.py
+++ b/tests/test_examples_smoke.py
@@ -18,22 +18,22 @@ _skip_ci = pytest.mark.skipif(IN_CI, reason="Too resource-heavy for CI runners")
 # Each tuple: (example_dir_name, config_name, epoch_overrides)
 EXAMPLE_CONFIGS = [
     # 01_minimal: single estimator 'z'
-    ("01_minimal", "config.yml", ["graph.z.estimator.loop.num_epochs=2"]),
+    ("01_minimal", "config.yml", ["graph.z.estimator.loop.max_epochs=2"]),
     # 02_bimodal: single estimator 'z', using config_regular (needs GPU override)
-    ("02_bimodal", "config_regular.yml", ["graph.z.estimator.loop.num_epochs=2", "graph.z.ray.num_gpus=0"]),
+    ("02_bimodal", "config_regular.yml", ["graph.z.estimator.loop.max_epochs=2", "graph.z.ray.num_gpus=0"]),
     # 03_composite: two ResNet18 + Ray actors exceed CI runner memory
     pytest.param(
         "03_composite", "config.yml",
-        ["graph.z1.estimator.loop.num_epochs=2", "graph.z2.estimator.loop.num_epochs=2",
+        ["graph.z1.estimator.loop.max_epochs=2", "graph.z2.estimator.loop.max_epochs=2",
          "graph.z1.ray.num_gpus=0", "graph.z2.ray.num_gpus=0"],
         marks=_skip_ci,
     ),
     # 04_gaussian: SNPE_gaussian with exponential forward model (needs GPU override)
-    ("04_gaussian", "config.yml", ["graph.z.estimator.loop.num_epochs=2", "graph.z.ray.num_gpus=0"]),
+    ("04_gaussian", "config.yml", ["graph.z.estimator.loop.max_epochs=2", "graph.z.ray.num_gpus=0"]),
     # 05_linear_regression: requires GPU
     pytest.param(
         "05_linear_regression", "config.yml",
-        ["graph.theta.estimator.loop.num_epochs=2", "graph.theta.ray.num_gpus=0"],
+        ["graph.theta.estimator.loop.max_epochs=2", "graph.theta.ray.num_gpus=0"],
         marks=_skip_ci,
     ),
 ]


### PR DESCRIPTION
## Summary

- Adds `prior_epochs: int = 0` to `TrainingLoopConfig` — when set, `sample_proposal()` falls back to the prior for the first N cumulative training epochs before the trained network takes over
- Tracks total epochs trained via `_total_epochs_trained` on `StepwiseEstimator`, persisted to `total_epochs_trained.pth` on save/load (old checkpoints default to 0)
- Epoch numbers in log messages and `history["epochs"]` now reflect cumulative epochs across all `train()` calls, so resumed runs no longer reset to 1
- Renames `num_epochs` → `max_epochs` in `TrainingLoopConfig` (breaking change) — aligns with PyTorch Lightning convention; early stopping makes it a ceiling, not a fixed count
- Applies to both `Flow` and `LossBasedEstimator` (and `Gaussian`, which is a `LossBasedEstimator` factory)

## Usage

```yaml
estimator:
  _target_: falcon.estimators.Flow
  loop:
    max_epochs: 300
    prior_epochs: 50    # use prior as proposal for first 50 epochs
```

Default `prior_epochs: 0` preserves existing behaviour. `max_epochs: 100` is the new name for `num_epochs`.

## Breaking changes

- `loop.num_epochs` → `loop.max_epochs` in all YAML configs (examples, docs, and tests updated)

## Test plan

- [ ] Run with `prior_epochs: 0` — confirm identical behaviour to before
- [ ] Run with `prior_epochs: N` — confirm `sample_proposal` returns prior samples for the first N epochs, then switches to the network
- [ ] Interrupt and resume a run with `prior_epochs` set — confirm epoch counter is restored and the transition point is preserved
- [ ] Confirm epoch numbers in logs count upward continuously across resumed runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)