### PR TITLE
Add warning when initial samples exceed max_samples

### DIFF
--- a/falcon/core/raystore.py
+++ b/falcon/core/raystore.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 import ray
 from omegaconf import MISSING
-from falcon.core.logger import Logger, set_logger, log, info, error
+from falcon.core.logger import Logger, set_logger, log, info, warning, error
 
 
 @dataclass
@@ -440,6 +440,12 @@ class DatasetManagerActor:
             if samples:
                 self.append(samples)
                 info(f"Loaded {len(samples)} initial samples from {self.initial_samples_path}")
+                if len(samples) > self.max_samples:
+                    warning(
+                        f"Loaded {len(samples)} initial samples but max_samples={self.max_samples}; "
+                        f"{len(samples) - self.max_samples} oldest samples were tombstoned immediately. "
+                        "Consider increasing buffer.max_samples."
+                    )
             return len(samples)
         return 0
 


### PR DESCRIPTION
## Summary
- Imports `warning` from `falcon.core.logger` in `raystore.py`
- Emits a warning after loading initial samples when the count exceeds `buffer.max_samples`, noting how many were tombstoned and suggesting the user increase `max_samples`

## Test plan
- [ ] Load an `initial_samples_path` with more samples than `max_samples` and confirm the warning appears in the log
- [ ] Verify normal case (samples ≤ max_samples) produces no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)