### PR TITLE
Rename store_fraction to snapshot_fraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ graph:
 │       ├── 000000.npz
 │       └── 000001.npz
 ├── buffer/
-│   └── snapshots/              # Buffer snapshots (when store_fraction > 0)
+│   └── snapshots/              # Buffer snapshots (when snapshot_fraction > 0)
 │       └── 000000.npz
 └── config.yml                 # Saved configuration
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ buffer:
   simulate_count: 64
   simulate_interval: 1
   simulate_when_full: true
-  store_fraction: 0.0
+  snapshot_fraction: 0.0
 ```
 
 | Key | Type | Default | Description |
@@ -65,7 +65,7 @@ buffer:
 | `simulate_count` | int | `64` | Number of new samples generated per simulation round. For simulators taking >1s per sample, keep this small (4–16) to avoid long delays between buffer updates; for fast simulators, increase to reduce Ray overhead. |
 | `simulate_interval` | float | `1` | Seconds between simulation rounds |
 | `simulate_when_full` | bool | `true` | If `true`, simulation continues after `max_samples` is reached and old samples are replaced; if `false`, simulation stops once the buffer is full |
-| `store_fraction` | float | `0.0` | Fraction of simulated samples written to `buffer/snapshots/` for inspection (0 = none, 1 = all) |
+| `snapshot_fraction` | float | `0.0` | Fraction of simulated samples written to `buffer/snapshots/` for inspection (0 = none, 1 = all) |
 
 ### `graph`
 

--- a/examples/01_minimal/config.yml
+++ b/examples/01_minimal/config.yml
@@ -58,7 +58,7 @@ buffer:
   simulate_count: 64                    # Number of new samples generated per simulation round
   simulate_when_full: true              # If true, keep simulating when buffer is full (old samples disfavoured); if false, stop at max_samples
   simulate_interval: 1                  # Seconds between simulation rounds
-  store_fraction: 0.1                   # Fraction of samples to dump to buffer/snapshots/ (0=none, 1=all)
+  snapshot_fraction: 0.1                   # Fraction of samples to dump to buffer/snapshots/ (0=none, 1=all)
 
 # -----------------------------------------------------------------------------
 # Graph definition using declarative YAML

--- a/examples/04_gaussian/config.yml
+++ b/examples/04_gaussian/config.yml
@@ -51,7 +51,7 @@ buffer:
   simulate_count: 512
   simulate_when_full: true
   simulate_interval: 1
-  store_fraction: 0.0
+  snapshot_fraction: 0.0
 
 # -----------------------------------------------------------------------------
 # Graph definition using SNPE_gaussian estimator

--- a/examples/05_linear_regression/config.yml
+++ b/examples/05_linear_regression/config.yml
@@ -53,7 +53,7 @@ buffer:
   simulate_chunk_size: 128
   simulate_when_full: true
   simulate_interval: 5
-  store_fraction: 0.0
+  snapshot_fraction: 0.0
 
 # -----------------------------------------------------------------------------
 # Graph definition using SNPE_gaussian estimator

--- a/falcon/core/raystore.py
+++ b/falcon/core/raystore.py
@@ -23,7 +23,7 @@ class BufferConfig:
     simulate_chunk_size: int = 0
     simulate_when_full: bool = True
     initial_samples_path: Optional[str] = None
-    store_fraction: float = 0.0
+    snapshot_fraction: float = 0.0
 
 
 class Batch:
@@ -137,7 +137,7 @@ class DatasetManagerActor:
         simulate_chunk_size,
         initial_samples_path,
         simulate_when_full,
-        store_fraction,
+        snapshot_fraction,
         log_config=None,
         snapshots_path=None,
     ):
@@ -150,7 +150,7 @@ class DatasetManagerActor:
         self.simulate_chunk_size = simulate_chunk_size
         self.initial_samples_path = initial_samples_path
         self.snapshots_path = Path(snapshots_path) if snapshots_path else None
-        self.store_fraction = store_fraction
+        self.snapshot_fraction = snapshot_fraction
 
         # NPZ storage state
         self._sample_counter = 0
@@ -363,12 +363,12 @@ class DatasetManagerActor:
         info(f"Appended {num_new_samples} samples | total={total_after} train={n_train} val={n_val}")
 
         # Disk dump: fetch values lazily if needed
-        if self.store_fraction > 0 and self.snapshots_path is not None:
+        if self.snapshot_fraction > 0 and self.snapshots_path is not None:
             self._dump_refs(sample_refs)
 
     def _dump_refs(self, sample_refs: list):
         """Fetch and dump samples to disk."""
-        interval = max(1, int(1.0 / self.store_fraction))
+        interval = max(1, int(1.0 / self.snapshot_fraction))
 
         for ref_dict in sample_refs:
             self._sample_counter += 1
@@ -385,15 +385,15 @@ class DatasetManagerActor:
         np.savez(sample_path, **sample)
 
     def dump_store(self, samples: list):
-        """Store samples to disk based on store_fraction.
+        """Store samples to disk based on snapshot_fraction.
 
         Args:
             samples: List of sample dicts to potentially store
         """
-        if self.store_fraction <= 0 or self.snapshots_path is None:
+        if self.snapshot_fraction <= 0 or self.snapshots_path is None:
             return
 
-        interval = max(1, int(1.0 / self.store_fraction))
+        interval = max(1, int(1.0 / self.snapshot_fraction))
 
         for sample in samples:
             self._sample_counter += 1

--- a/falcon/core/run_loader.py
+++ b/falcon/core/run_loader.py
@@ -66,7 +66,7 @@ class Run:
         """Access training buffer samples stored during training.
 
         Returns a SampleSetReader for buffer/snapshots.
-        Samples are stored when buffer.store_fraction > 0.
+        Samples are stored when buffer.snapshot_fraction > 0.
 
         Usage:
             run.buffer[0]           # First stored sample


### PR DESCRIPTION
## Summary

- Renames `buffer.store_fraction` → `buffer.snapshot_fraction` throughout configs, `BufferConfig`, `DatasetManagerActor`, and docs
- The old name was generic and unrelated to the `buffer/snapshots/` output directory introduced in #66; the new name makes the connection immediate

## Test plan

- [ ] `snapshot_fraction: 0.1` in config writes snapshots to `buffer/snapshots/`
- [ ] `snapshot_fraction: 0.0` (default) writes nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)