### PR TITLE
Add seconds to auto-generated run directory names

### DIFF
--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -6,7 +6,7 @@ Usage: falcon launch [--output DIR] [--config FILE] [key=value ...]
        falcon graph [--config FILE]
 
 Run directory behavior:
-  - If --output not specified, generates: output/adj-noun-YYMMDD-HHMM
+  - If --output not specified, generates: output/YYMMDD-HHMMSS-adj-noun
   - If --output exists with config.yml, resumes from saved config
   - Otherwise, loads ./config.yml and saves resolved config to output dir
 """

--- a/falcon/core/run_name.py
+++ b/falcon/core/run_name.py
@@ -6,11 +6,11 @@ from coolname import generate_slug
 
 
 def generate_run_name() -> str:
-    """Generate a memorable run name: YYMMDD-HHMM-adjective-noun."""
-    date = datetime.now().strftime("%y%m%d")
-    time = datetime.now().strftime("%H%M")
+    """Generate a memorable run name: YYMMDD-HHMMSS-adjective-noun."""
+    now = datetime.now()
+    date_time = now.strftime("%y%m%d-%H%M%S")
     slug = generate_slug(2)
-    return f"{date}-{time}-{slug}"
+    return f"{date_time}-{slug}"
 
 
 def generate_run_dir(base_dir: str = "output") -> str:


### PR DESCRIPTION
## Summary

- Changes the auto-generated output directory format from `YYMMDD-HHMM-adj-noun` to `YYMMDD-HHMMSS-adj-noun`
- Removes a redundant `datetime.now()` call (single call instead of two)
- Updates the docstring in `cli.py` to reflect the new format

## Motivation

The minute-precision format caused collisions when multiple runs were launched within the same minute. Adding seconds makes each run name unique under normal usage.

## Test plan

- [ ] `falcon launch` without `--output` produces a directory named `output/YYMMDD-HHMMSS-adj-noun`
- [ ] Re-running within the same minute produces a distinct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)