### PR TITLE
Fix gaussian_fullcov dtype mismatch; extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,12 +111,14 @@ runs/
 **/default-store-dir/
 **/default-graph-dir/
 **/outputs/
+**/output/
 **/*.zarr/
 
 # Data files
 #*.npz
 
 *.out
+*.log
 
 # MkDocs build output
 site/

--- a/falcon/estimators/gaussian_fullcov.py
+++ b/falcon/estimators/gaussian_fullcov.py
@@ -109,14 +109,15 @@ class _GaussianPosterior(nn.Module):
     def sample(self, conditions: torch.Tensor, gamma: Optional[float] = None) -> torch.Tensor:
         """Sample from posterior, optionally tempered.
 
-        Internal computation is float64 (output buffer precision).
-        Result is cast to conditions' dtype on return.
+        Result dtype matches the parameter-space buffers (i.e. the precision of the
+        training parameters), not the conditions dtype, which may be downcast to
+        float32 by the embedding layer.
 
         Args:
             conditions: Condition tensor of shape (batch, condition_dim)
             gamma: Tempering parameter. None = untempered, <1 = widened.
         """
-        out_dtype = conditions.dtype
+        out_dtype = self._output_mean.dtype
         mean = self._forward_mean(conditions)
         V = self._residual_eigvecs
         d = self._residual_eigvals


### PR DESCRIPTION
## Summary
- Fix dtype bug in `_GaussianPosterior.sample()`: output dtype was taken from `conditions.dtype`, which the embedding layer can downcast to float32, causing precision loss in the sampled parameters. Now uses `self._output_mean.dtype` (training parameter precision) instead.
- Extend `.gitignore` to ignore `**/output/` directories and `*.log` files.

## Test plan
- [ ] Run `04_gaussian` example and verify samples are in correct dtype (float64)
- [ ] Confirm `output/` dirs and `.log` files no longer appear as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)