### PR TITLE
Validate evidence vs embedding _input_ keys at graph construction time

### DIFF
--- a/falcon/core/graph.py
+++ b/falcon/core/graph.py
@@ -1,6 +1,7 @@
 import os
 import re
 import warnings
+from typing import Union
 
 import numpy as np
 from omegaconf import OmegaConf
@@ -436,6 +437,50 @@ def _validate_node_references(nodes: list, node_names: set) -> None:
                     )
 
 
+def _collect_input_keys(config: Union[dict, str, list]) -> list:
+    """Recursively collect all leaf _input_ keys from an embedding config."""
+    keys = []
+    if isinstance(config, str):
+        keys.append(config)
+    elif isinstance(config, list):
+        for item in config:
+            keys.extend(_collect_input_keys(item))
+    elif isinstance(config, dict) and "_input_" in config:
+        keys.extend(_collect_input_keys(config["_input_"]))
+    return list(set(keys))
+
+
+def _validate_evidence_vs_embedding(node_name: str, evidence: list, estimator_config: dict, scaffolds: list) -> None:
+    """Warn if evidence keys don't match embedding _input_ keys minus scaffolds.
+
+    A mismatch is a silent bug: the graph trains without error but the posterior
+    learns from the wrong nodes.
+    """
+    embedding_config = estimator_config.get("embedding")
+    if embedding_config is None:
+        return
+
+    input_keys = set(_collect_input_keys(embedding_config))
+    scaffold_set = set(scaffolds)
+    expected_evidence = input_keys - scaffold_set
+
+    evidence_set = set(evidence)
+    if evidence_set != expected_evidence:
+        missing = expected_evidence - evidence_set
+        extra = evidence_set - expected_evidence
+        parts = []
+        if missing:
+            parts.append(f"missing from 'evidence': {sorted(missing)}")
+        if extra:
+            parts.append(f"in 'evidence' but not in embedding '_input_': {sorted(extra)}")
+        warnings.warn(
+            f"Node '{node_name}': evidence/embedding mismatch — {'; '.join(parts)}. "
+            f"Expected evidence={sorted(expected_evidence)} derived from embedding '_input_' minus scaffolds.",
+            UserWarning,
+            stacklevel=4,
+        )
+
+
 def create_graph_from_config(graph_config, _cfg=None):
     """Create a computational graph from YAML configuration.
 
@@ -513,6 +558,10 @@ def create_graph_from_config(graph_config, _cfg=None):
         else:
             estimator_cls = None
             estimator_config = {}
+
+        # Validate evidence vs embedding _input_ keys
+        if estimator_config:
+            _validate_evidence_vs_embedding(node_name, evidence, estimator_config, scaffolds)
 
         # Create the node
         node = Node(

--- a/tests/test_graph_validation.py
+++ b/tests/test_graph_validation.py
@@ -1,0 +1,131 @@
+"""Tests for evidence/embedding _input_ mismatch validation in create_graph_from_config."""
+
+import pytest
+import warnings
+
+from omegaconf import OmegaConf
+
+from falcon.core.graph import (
+    _collect_input_keys,
+    _validate_evidence_vs_embedding,
+    create_graph_from_config,
+)
+
+
+class TestCollectInputKeys:
+    def test_string(self):
+        assert _collect_input_keys("x") == ["x"]
+
+    def test_list(self):
+        assert sorted(_collect_input_keys(["x", "y"])) == ["x", "y"]
+
+    def test_nested_dict(self):
+        config = {"_target_": "model.E", "_input_": ["x", "y"]}
+        assert sorted(_collect_input_keys(config)) == ["x", "y"]
+
+    def test_deeply_nested(self):
+        config = {
+            "_target_": "model.Outer",
+            "_input_": [
+                {"_target_": "model.A", "_input_": "x"},
+                {"_target_": "model.B", "_input_": "y"},
+            ],
+        }
+        assert sorted(_collect_input_keys(config)) == ["x", "y"]
+
+    def test_deduplicates(self):
+        config = {"_target_": "model.E", "_input_": ["x", "x"]}
+        assert _collect_input_keys(config) == ["x"]
+
+    def test_no_input_key(self):
+        assert _collect_input_keys({"_target_": "model.E"}) == []
+
+
+class TestValidateEvidenceVsEmbedding:
+    def _embedding(self, inputs):
+        return {"_target_": "model.E", "_input_": inputs}
+
+    def test_match_no_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _validate_evidence_vs_embedding(
+                "theta",
+                evidence=["x"],
+                estimator_config={"embedding": self._embedding("x")},
+                scaffolds=[],
+            )
+
+    def test_mismatch_missing_emits_warning(self):
+        with pytest.warns(UserWarning, match="missing from 'evidence'"):
+            _validate_evidence_vs_embedding(
+                "theta",
+                evidence=[],
+                estimator_config={"embedding": self._embedding("x")},
+                scaffolds=[],
+            )
+
+    def test_mismatch_extra_emits_warning(self):
+        with pytest.warns(UserWarning, match="in 'evidence' but not in embedding"):
+            _validate_evidence_vs_embedding(
+                "theta",
+                evidence=["x", "z"],
+                estimator_config={"embedding": self._embedding("x")},
+                scaffolds=[],
+            )
+
+    def test_scaffold_excluded_from_evidence(self):
+        # x is in _input_ but also a scaffold → should not appear in expected evidence
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _validate_evidence_vs_embedding(
+                "theta",
+                evidence=[],
+                estimator_config={"embedding": self._embedding(["x", "y"])},
+                scaffolds=["x", "y"],
+            )
+
+    def test_no_embedding_no_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _validate_evidence_vs_embedding(
+                "theta",
+                evidence=["x"],
+                estimator_config={"network": {}},
+                scaffolds=[],
+            )
+
+    def test_empty_estimator_config_no_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _validate_evidence_vs_embedding("theta", evidence=[], estimator_config={}, scaffolds=[])
+
+
+class TestCreateGraphFromConfigValidation:
+    """Integration: validate that create_graph_from_config raises the warning end-to-end."""
+
+    def _minimal_config(self, evidence, embedding_inputs):
+        # x has no parents here to avoid a backward-graph cycle in the topology sort
+        return {
+            "theta": {
+                "simulator": {"_target_": "falcon.priors.Hypercube", "priors": [["uniform", -1.0, 1.0]]},
+                "estimator": {
+                    "_target_": "falcon.estimators.Flow",
+                    "embedding": {"_target_": "model.E", "_input_": embedding_inputs},
+                },
+                "evidence": evidence,
+            },
+            "x": {
+                "simulator": {"_target_": "model.Simulator"},
+            },
+        }
+
+    def test_matching_evidence_no_warning(self):
+        config = OmegaConf.create(self._minimal_config(evidence=["x"], embedding_inputs="x"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            create_graph_from_config(config)
+
+    def test_mismatched_evidence_warns(self):
+        config = OmegaConf.create(self._minimal_config(evidence=[], embedding_inputs="x"))
+        with pytest.warns(UserWarning, match="evidence/embedding mismatch"):
+            create_graph_from_config(config)


### PR DESCRIPTION
Closes #95

## Summary

- Adds `_validate_evidence_vs_embedding()` in `falcon/core/graph.py` that emits a `UserWarning` whenever a node's `evidence` list doesn't match the leaf keys collected from its estimator's `embedding._input_` config (minus scaffolds).
- Adds `_collect_input_keys()` helper in `graph.py` (same logic as the one in `embeddings/builder.py`) to avoid a cross-module import at graph-construction time.
- Validation is called inside `create_graph_from_config` for every node that carries an estimator config with an embedding.

This is **Option A** from the issue: validation only, no interface changes to `BaseEstimator`.

## Test plan

- [ ] `_collect_input_keys`: string, list, nested dict, dedup, no-`_input_`
- [ ] `_validate_evidence_vs_embedding`: clean match, missing key, extra key, scaffold exclusion, no embedding present, empty estimator config
- [ ] Integration via `create_graph_from_config`: matching evidence → no warning; mismatched evidence → `UserWarning` with `"evidence/embedding mismatch"`
- [ ] All 14 new tests pass: `python -m pytest tests/test_graph_validation.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)