### PR TITLE
Default paths.graph and paths.samples — no more boilerplate in config.yml

### DIFF
--- a/examples/01_minimal/config.yml
+++ b/examples/01_minimal/config.yml
@@ -38,15 +38,12 @@ logging:
     dir: ${run_dir}                       # Directory for wandb files
   local:
     enabled: true                         # Local file-based logging
-    dir: ${paths.graph}                   # Reuses graph directory for metrics
 
 # -----------------------------------------------------------------------------
 # Directory configuration
 # -----------------------------------------------------------------------------
 paths:
   imports: ["./src"]                      # Local folder(s) with user-defined code (e.g. model.py)
-  graph: ${run_dir}/graph               # Directory for serialized graph and trained networks
-  samples: ${run_dir}/samples           # Directory for generated samples (posterior, prior, etc.)
 
 # -----------------------------------------------------------------------------
 # Training buffer parameters
@@ -108,4 +105,4 @@ graph:
 sample:
   posterior:
     n: 1000                             # Number of posterior samples to draw
-    # Output: ${paths.samples}/posterior/
+    # Output: ${run_dir}/samples/posterior/

--- a/examples/03_composite/config.yml
+++ b/examples/03_composite/config.yml
@@ -7,13 +7,10 @@ logging:
     dir: ${run_dir}
   local:
     enabled: true
-    dir: ${paths.graph}
 
 # Directory configuration
 paths:
   imports: ["./src"]
-  graph: ${run_dir}/graph
-  samples: ${run_dir}/samples
 
 # Training buffer parameters
 buffer:

--- a/examples/04_gaussian/config.yml
+++ b/examples/04_gaussian/config.yml
@@ -31,15 +31,12 @@ logging:
     dir: ${run_dir}
   local:
     enabled: true
-    dir: ${paths.graph}
 
 # -----------------------------------------------------------------------------
 # Directory configuration
 # -----------------------------------------------------------------------------
 paths:
   imports: ["./src"]
-  graph: ${run_dir}/graph
-  samples: ${run_dir}/samples
 
 # -----------------------------------------------------------------------------
 # Training buffer parameters

--- a/examples/05_linear_regression/config.yml
+++ b/examples/05_linear_regression/config.yml
@@ -30,7 +30,6 @@ logging:
     dir: ${run_dir}
   local:
     enabled: true
-    dir: ${paths.graph}
   console:
     level: DEBUG
 
@@ -39,8 +38,6 @@ logging:
 # -----------------------------------------------------------------------------
 paths:
   imports: ["./src"]
-  graph: ${run_dir}/graph
-  samples: ${run_dir}/samples
 
 # -----------------------------------------------------------------------------
 # Training buffer parameters

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -100,12 +100,10 @@ def shutdown() -> None:
 
 _DEFAULT_GRAPH_CONFIG = {
     "logging": {
-        "local": {"enabled": True, "dir": "${paths.graph}"},
+        "local": {"enabled": True},
     },
     "paths": {
         "imports": [],
-        "graph": "${run_dir}/graph",
-        "samples": "${run_dir}/samples",
     },
     "buffer": {
         "min_samples": 4096,

--- a/falcon/cli.py
+++ b/falcon/cli.py
@@ -234,13 +234,18 @@ def load_config(config_name: str = "config.yml", run_dir: str = None, overrides:
 
 
 def _resolve_paths(cfg):
-    """Merge cfg.paths against PathConfig and return a plain dict."""
+    """Merge cfg.paths against PathConfig and return a plain dict with defaults applied."""
     from omegaconf import OmegaConf
     from falcon.core.raystore import PathConfig as _PathConfig
-    return OmegaConf.to_container(
+    result = OmegaConf.to_container(
         OmegaConf.merge(OmegaConf.structured(_PathConfig), cfg.paths),
         resolve=True,
     )
+    run_dir = cfg.run_dir
+    result["graph"] = result["graph"] or f"{run_dir}/graph"
+    result["samples"] = result["samples"] or f"{run_dir}/samples"
+    result["buffer"] = result["buffer"] or f"{run_dir}/buffer"
+    return result
 
 
 class TeeOutput:
@@ -329,7 +334,7 @@ def _build_run_summary(status, output_dir, cfg, deployed_graph, start_time=None,
     lines.append(f"falcon launch {status}")
     lines.append(f"Output:  {output_dir}")
     paths = _resolve_paths(cfg)
-    lines.append(f"Samples: {paths['samples'] or f'{cfg.run_dir}/samples'}")
+    lines.append(f"Samples: {paths['samples']}")
     graph_path = Path(paths['graph'])
     lines.append(f"Logs:    {graph_path / 'driver' / 'output.log'}  (driver)")
     try:
@@ -461,7 +466,7 @@ def _save_samples(samples, sample_cfg, sample_type, graph, cfg, info_fn=print):
         info_fn(f"  {key}: {value.shape}")
 
     # Determine output directory (flat structure)
-    samples_dir = _resolve_paths(cfg)["samples"] or f"{cfg.run_dir}/samples"
+    samples_dir = _resolve_paths(cfg)["samples"]
     output_dir = Path(samples_dir) / sample_type
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -605,7 +610,7 @@ def _run_pipeline(
         from omegaconf import OmegaConf as _OmegaConf
         from falcon.core.raystore import BufferConfig as _BufferConfig
         buffer_cfg = _OmegaConf.merge(_OmegaConf.structured(_BufferConfig), cfg.buffer)
-        buffer_base = path_cfg["buffer"] or str(Path(cfg.run_dir) / "buffer")
+        buffer_base = path_cfg["buffer"]
         dataset_manager = falcon.get_ray_dataset_manager(
             buffer_cfg,
             snapshots_path=str(Path(buffer_base) / "snapshots"),

--- a/falcon/core/raystore.py
+++ b/falcon/core/raystore.py
@@ -15,7 +15,7 @@ from falcon.core.logger import Logger, set_logger, log, info, warning, error
 class PathConfig:
     """Configuration for file-system paths."""
 
-    graph: str = MISSING
+    graph: Optional[str] = None
     samples: Optional[str] = None
     buffer: Optional[str] = None
     imports: Optional[List[str]] = None  # directories prepended to sys.path in Ray workers


### PR DESCRIPTION
## Summary

- `paths.graph` and `paths.samples` no longer need to be declared in `config.yml` — they default to `{run_dir}/graph` and `{run_dir}/samples`
- All three path defaults (graph, samples, buffer) are now applied centrally in `_resolve_paths` instead of being scattered as `or f'{run_dir}/...'` fallbacks across call sites
- `logging.local.dir` removed from example configs (it was being overridden in code anyway)
- `paths.graph`/`paths.samples` removed from all four example configs

## Changes

- `PathConfig.graph`: `MISSING` → `Optional[str] = None`
- `_resolve_paths`: applies defaults for all three paths after merge
- `api.py` `_DEFAULT_GRAPH_CONFIG`: stripped redundant path/logging keys
- Example configs: `paths` section now only needs `imports`

## Test plan

- [x] 49/49 existing tests pass
- [ ] Smoke-test `falcon launch` in an example dir without `paths.graph`/`paths.samples` in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)