### PR TITLE
Mixture-proposal importance sampling for Flow estimator

### DIFF
--- a/falcon/estimators/flow.py
+++ b/falcon/estimators/flow.py
@@ -44,6 +44,11 @@ class Flow(StepwiseEstimator):
         sample_reference_posterior: Sample reference posterior for proposals.
         use_best_models: Use best-checkpoint networks for sampling.
         num_proposals: Importance sampling proposal count.
+        proposal_mixture_beta: Fraction of proposals drawn from the conditional
+            flow in the multiple-importance-sampling mixture (balance heuristic);
+            the rest are drawn from the marginal flow. ``1.0`` = conditional
+            only (reproduces the single-proposal behaviour), ``0.0`` = marginal
+            only, ``0.5`` = even defensive mixture.
         reference_samples: Reference posterior sample count.
         hypercube_bound: Hypercube clipping bound for proposals.
         out_of_bounds_penalty: Log-weight penalty for out-of-bounds samples.
@@ -82,6 +87,7 @@ class Flow(StepwiseEstimator):
         sample_reference_posterior: bool = False,
         use_best_models: bool = True,
         num_proposals: int = 256,
+        proposal_mixture_beta: float = 0.5,
         reference_samples: int = 128,
         hypercube_bound: float = 2.0,
         out_of_bounds_penalty: float = 100.0,
@@ -111,6 +117,7 @@ class Flow(StepwiseEstimator):
         self.sample_reference_posterior = sample_reference_posterior
         self.use_best_models = use_best_models
         self.num_proposals = num_proposals
+        self.proposal_mixture_beta = proposal_mixture_beta
         self.reference_samples = reference_samples
         self.hypercube_bound = hypercube_bound
         self.out_of_bounds_penalty = out_of_bounds_penalty
@@ -342,24 +349,67 @@ class Flow(StepwiseEstimator):
         s = s.expand(num_samples, *s.shape[1:])
 
         conditional_net.eval()
-        samples_proposals = conditional_net.sample(self.num_proposals, s).detach()
+        marginal_net.eval()
+
+        # Multiple importance sampling: draw the proposals from a mixture of the
+        # conditional and marginal flows -- beta of them from the conditional and
+        # (1 - beta) from the marginal -- keeping the total proposal count fixed.
+        # The marginal flow is the broad/defensive component that covers the tails
+        # the (tempered) conditional under-covers; the conditional gives efficiency
+        # near the mode. The mixture-density weighting below is the balance
+        # heuristic, which is also a defensive mixture in Hesterberg's sense.
+        # Refs:
+        #   Hesterberg (1995), "Weighted Average Importance Sampling and
+        #     Defensive Mixture Distributions", Technometrics 37(2):185-194.
+        #     DOI: 10.1080/00401706.1995.10484303
+        #   Veach & Guibas (1995), "Optimally Combining Sampling Techniques
+        #     for Monte Carlo Rendering", SIGGRAPH '95, pp. 419-428
+        #     DOI: 10.1145/218380.218498
+        #     Introduces multiple importance sampling; includes the balance heuristic.
+        n_cond = int(round(self.proposal_mixture_beta * self.num_proposals))
+        n_cond = max(0, min(self.num_proposals, n_cond))
+        n_marg = self.num_proposals - n_cond
+
+        parts = []
+        if n_cond > 0:
+            parts.append(conditional_net.sample(n_cond, s).detach())
+        if n_marg > 0:
+            parts.append(marginal_net.sample(n_marg, s * 0).detach())
+        samples_proposals = torch.cat(parts, dim=0)
 
         log({
             "importance_sample:proposal_mean": samples_proposals.mean().item(),
             "importance_sample:proposal_std": samples_proposals.std().item(),
         })
 
+        # Both densities must be evaluated on the full pooled set, regardless of
+        # which flow drew each sample (this is what the balance heuristic needs).
         log_prob_cond = conditional_net.log_prob(samples_proposals, s)
-        marginal_net.eval()
         log_prob_marg = marginal_net.log_prob(samples_proposals, s * 0)
 
         mask = (samples_proposals < -self.hypercube_bound) | (samples_proposals > self.hypercube_bound)
         mask = mask.any(dim=-1).float() * self.out_of_bounds_penalty
 
+        # Balance-heuristic mixture density: sum_k (n_k / N) * g_k(theta).
+        total = n_cond + n_marg
+        mix_terms = []
+        if n_cond > 0:
+            mix_terms.append(np.log(n_cond / total) + log_prob_cond)
+        if n_marg > 0:
+            mix_terms.append(np.log(n_marg / total) + log_prob_marg)
+        log_g_mix = (
+            torch.logaddexp(mix_terms[0], mix_terms[1])
+            if len(mix_terms) == 2 else mix_terms[0]
+        )
+
+        # Unnormalised target: tempered posterior c^{gamma/(1+gamma)} for the
+        # proposal distribution; importance-corrected posterior c/m otherwise.
         if mode == "proposal":
-            log_weights = -1.0 / (1.0 + self.gamma) * log_prob_cond - mask
+            log_target = self.gamma / (1.0 + self.gamma) * log_prob_cond
         else:
-            log_weights = -log_prob_marg - mask
+            log_target = log_prob_cond - log_prob_marg
+
+        log_weights = log_target - log_g_mix - mask
 
         log_weights = torch.nan_to_num(log_weights, nan=self.nan_replacement, neginf=self.nan_replacement)
         log_weights = log_weights - torch.logsumexp(log_weights, dim=0, keepdim=True)

--- a/falcon/estimators/flow_density.py
+++ b/falcon/estimators/flow_density.py
@@ -54,6 +54,7 @@ class FlowDensity(torch.nn.Module):
                 momentum=norm_momentum,
                 use_log_update=use_log_update,
                 adaptive_momentum=adaptive_momentum,
+                log_prefix = "FlowDensity:OnlineNorm",
             )
             if theta_norm
             else None


### PR DESCRIPTION
## Summary

Generalises `Flow._importance_sample` to draw proposals from a **mixture** of the conditional and marginal flows instead of a single flow, weighted by the **balance heuristic** (multiple importance sampling). This is a defensive mixture in Hesterberg's sense: the marginal flow is the broad component that covers the tails the (tempered) conditional under-covers, while the conditional flow gives efficiency near the mode. The mixture density is used as the weight denominator, which bounds the worst-case importance weight and raises the effective sample size (`importance_sample:n_eff_min`).

### What changed

- New `proposal_mixture_beta` parameter (default `0.5`): fraction of the `num_proposals` drawn from the conditional flow; the rest are drawn from the marginal flow. Total proposal count is unchanged, so per-call cost is the same.
- Proposals are pooled from both flows; **both** `log_prob_cond` and `log_prob_marg` are evaluated on the full pooled set (required for the balance heuristic, regardless of which flow drew each sample).
- Weight denominator is the balance-heuristic mixture density `Σ_k (n_k / N) · g_k(θ)`, computed from the actual sampled counts (exact under rounding).
- Targets are unchanged: tempered posterior `c^{γ/(1+γ)}` for proposal mode, importance-corrected posterior `c/m` for posterior mode.
- Small unrelated tidy-up: added a `log_prefix` to the `FlowDensity` online-norm logger so its metrics are namespaced.

### Behaviour / compatibility

- `proposal_mixture_beta=1.0` **exactly reproduces** the previous single-proposal behaviour in both modes (verified by reduction: `log_g_mix → log_prob_cond`, so the proposal weight collapses to `−1/(1+γ)·log c` and the posterior weight to `−log m`). Use it as a revert switch.
- The default `0.5` **changes sampling results** vs. `main` (this is the intended mixture). Watch `importance_sample:n_eff_min` — it should increase.

### Refs

- Hesterberg (1995), *Weighted Average Importance Sampling and Defensive Mixture Distributions*, Technometrics 37(2):185-194.
- Veach & Guibas (1995), *Optimally Combining Sampling Techniques for Monte Carlo Rendering*, SIGGRAPH '95 (balance heuristic).

### Test plan

- [x] `python -m py_compile falcon/estimators/flow.py`
- [ ] Smoke-test a Flow run and confirm `n_eff_min` is ≥ the `beta=1.0` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)