### PR TITLE
core: simulation scheduling fixes + buffer accounting

### DIFF
--- a/src/falcon/core/deployed_graph.py
+++ b/src/falcon/core/deployed_graph.py
@@ -833,6 +833,7 @@ class DeployedGraph:
 
         train_future_list = list(train_futures.keys())
         stop_requested = False
+        pending_append = None
         while train_future_list:
             # Check for graceful stop request
             if stop_check is not None and stop_check():
@@ -879,7 +880,11 @@ class DeployedGraph:
                             {k: v for k, v in prop_ref.items()
                              if k.split(".")[0] in latent_nodes}
                         )
-                    ray.get(dataset_manager.append_refs.remote(sample_refs))
+                    # Pipeline the append: block on the *previous* one, then
+                    # fire this one and let it overlap the next simulation.
+                    if pending_append is not None:
+                        ray.get(pending_append)
+                    pending_append = dataset_manager.append_refs.remote(sample_refs)
 
             # Periodic status update (every ~60 seconds)
             now = time.time()
@@ -899,6 +904,10 @@ class DeployedGraph:
                         info(f"[{node_name}] Training completed (loss: {loss:.4f})")
                     else:
                         info(f"[{node_name}] Training completed")
+
+        # Flush the last deferred buffer append before shutdown.
+        if pending_append is not None:
+            ray.get(pending_append)
 
         # Save graph if path is provided
         if graph_path is not None:

--- a/src/falcon/core/deployed_graph.py
+++ b/src/falcon/core/deployed_graph.py
@@ -845,8 +845,10 @@ class DeployedGraph:
                     except Exception:
                         pass  # Node may not support request_stop
 
+            # Short poll: the loop's own pacing comes from the time.sleep()
+            # below, so a long timeout here just adds to simulate_interval.
             ready, train_future_list = ray.wait(
-                train_future_list, num_returns=len(train_future_list), timeout=1
+                train_future_list, num_returns=len(train_future_list), timeout=0.05
             )
 
             # Skip simulation if stopping

--- a/src/falcon/core/deployed_graph.py
+++ b/src/falcon/core/deployed_graph.py
@@ -57,6 +57,11 @@ class MultiplexNodeWrapper:
 
         futures = []
         for i, (start, end) in enumerate(index_range_list):
+            if end - start <= 0:
+                # n_samples < num_actors leaves some actors with an empty
+                # slice; a zero-sample dispatch is rejected by _resolve_refs
+                # (explicit ValueError). Skip idle actors instead.
+                continue
             chunk_refs = {k: v[start:end] for k, v in condition_refs.items()} if condition_refs else None
             method = getattr(self.wrapped_node_list[i], method_name)
             futures.append(method.remote(end - start, condition_refs=chunk_refs))
@@ -254,6 +259,10 @@ class NodeWrapper:
         all_refs = []
         slices = {}
         for name, refs in condition_refs.items():
+            if len(refs) == 0:
+                raise ValueError(
+                    f"_resolve_refs: empty ref list for '{name}' "
+                    f"(zero-sample dispatch? n_samples < num_actors?)")
             if len(set(refs)) == 1:  # all same ref → broadcast
                 slices[name] = ('broadcast', len(all_refs))
                 all_refs.append(refs[0])

--- a/src/falcon/core/raystore.py
+++ b/src/falcon/core/raystore.py
@@ -331,7 +331,11 @@ class DatasetManagerActor:
         log({
             "n_total": len(self.ray_store),
             "n_validation": int(sum(self.status == SampleStatus.VALIDATION)),
-            "n_training": int(sum(self.status == SampleStatus.TRAINING)),
+            # n_training = the actual trainable pool: the dataloader draws from TRAINING +
+            # DISFAVOURED and min_samples floors their sum (see rotate_sample_buffer). n_disfavoured
+            # below is the subset marked for eviction (still trained on until tombstoned).
+            "n_training": int(sum((self.status == SampleStatus.TRAINING)
+                                  | (self.status == SampleStatus.DISFAVOURED))),
             "n_disfavoured": int(sum(self.status == SampleStatus.DISFAVOURED)),
             "n_tombstone": int(sum(self.status == SampleStatus.TOMBSTONE)),
             "n_deleted": int(sum(self.status == SampleStatus.DELETED)),
@@ -359,7 +363,9 @@ class DatasetManagerActor:
         self.rotate_sample_buffer()
 
         # Log buffer statistics
-        n_train = int(sum(self.status == SampleStatus.TRAINING))
+        # trainable pool = TRAINING + DISFAVOURED (what the dataloader draws; min_samples floors it)
+        n_train = int(sum((self.status == SampleStatus.TRAINING)
+                          | (self.status == SampleStatus.DISFAVOURED)))
         n_val = int(sum(self.status == SampleStatus.VALIDATION))
         log({
             "n_total": len(self.ray_store),

--- a/src/falcon/core/raystore.py
+++ b/src/falcon/core/raystore.py
@@ -191,7 +191,7 @@ class DatasetManagerActor:
         if self.simulate_when_full:
             return self.simulate_count
         else:
-            num_train_samples = sum(self.status == SampleStatus.TRAINING)
+            num_train_samples = int((self.status == SampleStatus.TRAINING).sum())
             return min(
                 self.simulate_count, self.max_samples - num_train_samples
             )


### PR DESCRIPTION
Four independent core fixes extracted from `plan/gaussianized-flow-matching`, where they were developed alongside the GFM estimator. None of them touch estimator code, so they can land ahead of that work.

Each commit stands alone and is individually revertable.

## Commits

### 1. `core: zero-sample dispatch guards + native-int num_resims` (cherry-pick of `d46aac4`)

**Crash fix.** When `n_samples < num_actors`, `MultiplexNodeWrapper._multiplexed_call` hands some actors an empty index slice. That reaches `_resolve_refs`, where an empty ref list falls past the broadcast check into `np.stack([])` and dies with an unhelpful `need at least one array to stack`.

Idle actors are now skipped, and `_resolve_refs` gained an explicit `ValueError` as a backstop that names the actual cause. Also converts `num_resims()` from `np.int64` to a native `int`.

No behaviour change on the normal path.

### 2. `core: report the actual trainable pool in buffer/n_training` (extracted from `e712a3e`)

**Metric fix, logging only.** `buffer/n_training` counted only `SampleStatus.TRAINING`, but `BufferView.cached_loader` draws from `[TRAINING, DISFAVOURED]` and `rotate_sample_buffer` floors that *sum* at `min_samples`. The metric therefore read below `min_samples` as soon as anything was disfavoured, even though those samples are still being trained on until tombstoned.

`n_disfavoured` is unchanged and still shows the eviction-pending subset, so the split stays visible.

### 3. `core: stop the ray.wait timeout from inflating simulate_interval` (from `6f4c6bb`)

⚠️ **Behaviour change — please read.**

The launch loop paces itself with `time.sleep(simulate_interval)`, but each iteration first sat in `ray.wait(..., timeout=1)`. The real cadence was `simulate_interval + 1s`. At the common `simulate_interval=1` that halved the simulation rate relative to the configured value.

The poll timeout drops to 0.05s so `simulate_interval` means what it says. **Existing configs will simulate roughly 2x faster at `simulate_interval=1`**, converging to no change as `simulate_interval` grows. Anything tuned against the old effective cadence wants `simulate_interval` raised by ~1s to match.

Side effect: during a graceful stop the sleep is skipped, so the loop polls at 50ms rather than 1s while training winds down.

### 4. `core: overlap the buffer append with the next simulation round` (from `6f4c6bb`)

`append_refs()` was awaited synchronously, stalling the launch loop on the dataset-manager actor (a `ray.put` per sample, plus `rotate_sample_buffer`) before the next simulation round could start. Now one append stays in flight, with a flush at loop exit so nothing is lost at shutdown.

Consequence: `num_resims()` is queried before the previous append lands, so the buffer can transiently exceed `max_samples` by up to one `simulate_count` batch. `rotate_sample_buffer()` tombstones the excess on the next append, so the steady state is unchanged. Exceptions from `append_refs` now surface one iteration later.

Commits 3 and 4 were one commit upstream; they are split here because 3 changes observable behaviour and 4 does not, so 3 should be bisectable and revertable on its own.

## Testing

Not run — `import torch` fails in my environment (`libcudnn.so.9: cannot open shared object file`), which also breaks `pytest tests` collection on `main`, so it is not something this branch introduces. Verification so far is static review plus `py_compile`.

**`tests/test_examples_smoke.py` should be run on a GPU node before merge**, mainly to exercise commit 3's timing change end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)