### PR TITLE
Product: 'marginalize' role for nuisance parameters

### DIFF
--- a/src/falcon/priors/product.py
+++ b/src/falcon/priors/product.py
@@ -281,14 +281,19 @@ class Product(TransformedPrior):
         # Free and marginalized params are both drawn from their own prior; only
         # fixed params take a constant. (Marginalized params are absent from the
         # latent space but still fed to the simulator, so they must be sampled.)
+        # Note this is _param_dim + len(marginalize), not _param_dim.
+        num_sampled = len(self.priors) - len(self._fixed_indices)
+        u = torch.rand(batch_size, num_sampled, dtype=torch.float64)
+
         transformed = []
+        u_idx = 0
         for i, prior in enumerate(self.priors):
             dist_type, *params = prior
             if dist_type == "fixed":
                 x_i = torch.full((batch_size,), params[0], dtype=torch.float64)
             else:
-                u_i = torch.rand(batch_size, dtype=torch.float64)
-                x_i = self._forward_transform(u_i, dist_type, *params)
+                x_i = self._forward_transform(u[..., u_idx], dist_type, *params)
+                u_idx += 1
             transformed.append(x_i)
 
         return torch.stack(transformed, dim=-1).numpy()

--- a/src/falcon/priors/product.py
+++ b/src/falcon/priors/product.py
@@ -68,19 +68,31 @@ class Product(TransformedPrior):
       - "triangular": Triangular distribution. Parameters: a (min), c (mode), b (max).
       - "fixed": Fixed value (excluded from latent space). Parameters: value.
 
+    Two roles exclude a parameter from the latent space, i.e. from what the
+    estimator infers.  They differ in what the simulator receives:
+      - "fixed": pinned to a constant, so it cannot influence the data at all.
+      - marginalize=[i, ...]: keeps its declared distribution and is redrawn
+        from it on every call, so it still varies and still broadens the
+        likelihood -- the estimator learns the posterior marginalized over it.
+        Use for nuisance parameters.  Note that forward() cannot recover a
+        marginalized value from the latent vector, so the corresponding column
+        of any generated sample is a *prior* draw, not a posterior draw; the
+        marginals of the remaining parameters are unaffected.
+
     Example:
         prior = Product([
             ("uniform", -100.0, 100.0),
             ("fixed", 5.0),              # Fixed parameter, not in latent space
             ("normal", 0.0, 1.0),
-        ])
+            ("uniform", 0.0, 1.0),       # Nuisance, marginalized over
+        ], marginalize=[3])
 
         # Latent space has dim=2 (only free params)
-        # Output space has dim=3 (includes fixed params)
+        # Output space has dim=4 (includes fixed and marginalized params)
 
         # For Gaussian estimator (standard normal latent space)
-        z = prior.inverse(theta, mode="standard_normal")  # theta: (..., 3) -> z: (..., 2)
-        theta = prior.forward(z, mode="standard_normal")  # z: (..., 2) -> theta: (..., 3)
+        z = prior.inverse(theta, mode="standard_normal")  # theta: (..., 4) -> z: (..., 2)
+        theta = prior.forward(z, mode="standard_normal")  # z: (..., 2) -> theta: (..., 4)
 
         # For Flow estimator (hypercube latent space)
         u = prior.inverse(theta, mode="hypercube")

--- a/src/falcon/priors/product.py
+++ b/src/falcon/priors/product.py
@@ -87,18 +87,30 @@ class Product(TransformedPrior):
         theta = prior.forward(u, mode="hypercube")
     """
 
-    def __init__(self, priors=[], hypercube_range=[-2, 2]):
+    def __init__(self, priors=[], hypercube_range=[-2, 2], marginalize=None):
         """
         Initialize Product.
 
         Args:
             priors: List of tuples (dist_type, param1, param2, ...).
             hypercube_range: Range for hypercube mode (default: [-2, 2]).
+            marginalize: Optional list of parameter indices to marginalize over.
+                A marginalized param keeps its declared distribution and is
+                sampled normally into the full/simulator vector (so it still
+                affects the data), but is excluded from the latent/inference
+                space -- the estimator learns the posterior marginalized over
+                it. Like "fixed" in that it is absent from the latent space,
+                but drawn from its own prior (a fresh random draw in forward())
+                rather than held at a constant value. Composes with everything
+                downstream because the latent space is simply smaller.
         """
         self.priors = priors
         self.hypercube_range = hypercube_range
 
-        # Separate fixed and free parameters
+        # Separate fixed, marginalized, and free parameters. Fixed and
+        # marginalized params are both excluded from the latent space: fixed
+        # take a constant value, marginalized are drawn from their own prior.
+        self._marginalize_set = set(marginalize or [])
         self._free_indices = []
         self._fixed_indices = []
         self._fixed_values = {}
@@ -107,8 +119,16 @@ class Product(TransformedPrior):
             if dist_type == "fixed":
                 self._fixed_indices.append(i)
                 self._fixed_values[i] = prior[1]
+            elif i in self._marginalize_set:
+                continue  # sampled but not in latent; handled in forward/simulate
             else:
                 self._free_indices.append(i)
+
+        for i in self._marginalize_set:
+            if not 0 <= i < len(priors):
+                raise ValueError(f"marginalize index {i} out of range [0,{len(priors)})")
+            if priors[i][0] == "fixed":
+                raise ValueError(f"marginalize index {i} is a 'fixed' param; use one or the other")
 
         self._param_dim = len(self._free_indices)  # Latent space dimension
         self._full_param_dim = len(priors)  # Full output dimension
@@ -142,6 +162,8 @@ class Product(TransformedPrior):
             result = torch.zeros(*batch_shape, self._full_param_dim, dtype=z.dtype, device=z.device)
             for idx, val in self._fixed_values.items():
                 result[..., idx] = val
+            for idx in self._marginalize_set:
+                result[..., idx] = self._sample_marginal(idx, batch_shape, z.dtype, z.device)
             return result
 
         if mode == "standard_normal":
@@ -153,6 +175,8 @@ class Product(TransformedPrior):
                 dist_type, *params = prior
                 if dist_type == "fixed":
                     transformed[i] = torch.full(z.shape[:-1], params[0], dtype=z.dtype, device=z.device)
+                elif i in self._marginalize_set:
+                    transformed[i] = self._sample_marginal(i, z.shape[:-1], z.dtype, z.device)
                 else:
                     x_i = self._from_standard_normal(z[..., z_idx], dist_type, *params)
                     if x_i is None:
@@ -179,6 +203,8 @@ class Product(TransformedPrior):
             dist_type, *params = prior
             if dist_type == "fixed":
                 x_i = torch.full(u.shape[:-1], params[0], dtype=u.dtype, device=u.device)
+            elif i in self._marginalize_set:
+                x_i = self._sample_marginal(i, u.shape[:-1], u.dtype, u.device)
             else:
                 x_i = self._forward_transform(u[..., u_idx], dist_type, *params)
                 u_idx += 1
@@ -208,8 +234,8 @@ class Product(TransformedPrior):
             use_direct = True
             for i, prior in enumerate(self.priors):
                 dist_type, *params = prior
-                if dist_type == "fixed":
-                    continue  # Skip fixed parameters
+                if dist_type == "fixed" or i in self._marginalize_set:
+                    continue  # excluded from the latent space
                 z_i = self._to_standard_normal(x[..., i], dist_type, *params)
                 if z_i is None:
                     use_direct = False
@@ -223,8 +249,8 @@ class Product(TransformedPrior):
         uniform = []
         for i, prior in enumerate(self.priors):
             dist_type, *params = prior
-            if dist_type == "fixed":
-                continue  # Skip fixed parameters
+            if dist_type == "fixed" or i in self._marginalize_set:
+                continue  # excluded from the latent space
             u_i = self._inverse_transform(x[..., i], dist_type, *params)
             uniform.append(u_i)
 
@@ -252,21 +278,33 @@ class Product(TransformedPrior):
         Returns:
             numpy array of shape (batch_size, full_param_dim) in target distribution space.
         """
-        # Sample uniform for free parameters only
-        u = torch.rand(batch_size, self._param_dim, dtype=torch.float64)
-
+        # Free and marginalized params are both drawn from their own prior; only
+        # fixed params take a constant. (Marginalized params are absent from the
+        # latent space but still fed to the simulator, so they must be sampled.)
         transformed = []
-        u_idx = 0
         for i, prior in enumerate(self.priors):
             dist_type, *params = prior
             if dist_type == "fixed":
                 x_i = torch.full((batch_size,), params[0], dtype=torch.float64)
             else:
-                x_i = self._forward_transform(u[..., u_idx], dist_type, *params)
-                u_idx += 1
+                u_i = torch.rand(batch_size, dtype=torch.float64)
+                x_i = self._forward_transform(u_i, dist_type, *params)
             transformed.append(x_i)
 
         return torch.stack(transformed, dim=-1).numpy()
+
+    # ==================== Marginalized Parameters ====================
+
+    def _sample_marginal(self, idx, batch_shape, dtype, device):
+        """Fresh random draw from the declared prior of a marginalized param.
+
+        Marginalized params are excluded from the latent space, so forward()
+        cannot recover their value from z; it injects an independent prior
+        sample instead. The marginalization is realized by this randomness at
+        simulation time plus the param's exclusion from the learned density."""
+        dist_type, *params = self.priors[idx]
+        u = torch.rand(batch_shape, dtype=dtype, device=device)
+        return self._forward_transform(u, dist_type, *params)
 
     # ==================== Latent Space Conversions ====================
 


### PR DESCRIPTION
Extracted from `plan/gaussianized-flow-matching` (`9c91d11`), where it was developed alongside the GFM estimator. Touches only `priors/product.py`.

## What it does

Adds a third role for a parameter, alongside free and `"fixed"`. All three differ only in what reaches the latent space vs. what reaches the simulator:

| role | in latent space (inferred) | value handed to the simulator |
|---|---|---|
| free | yes | recovered from the latent vector |
| `"fixed"` | no | a constant |
| `marginalize=[i]` | no | **a fresh draw from its own prior** |

A marginalized parameter keeps varying at simulation time, so it still affects the data and still broadens the likelihood — the estimator just never sees it and therefore learns the posterior marginalized over it. That is the usual nuisance-parameter treatment, and it composes with everything downstream because the latent space is simply smaller.

```yaml
simulator:
  _target_: falcon.priors.Product
  priors:
    - ['uniform', -1.0, 1.0]    # 0  amplitude    <- inferred
    - ['uniform', -1.0, 1.0]    # 1  position     <- inferred
    - ['uniform',  0.1, 2.0]    # 2  width        <- inferred
    - ['normal',   0.0, 1.0]    # 3  gain drift   <- nuisance
    - ['uniform',  0.0, 6.283]  # 4  phase        <- nuisance
  marginalize: [3, 4]
```

Indices are 0-based positions in the full `priors` list, matching the `"fixed"` convention. `graph.py` runs `OmegaConf.to_container(..., resolve=True)` before instantiating, so the YAML list arrives as native ints — no extra wiring needed.

Here the network's latent dim is 3 while the simulator still receives all 5 columns; `theta.value` stays 5-wide in the buffer, and the existing `inverse()` / `forward()` round trip at `flow.py:222` / `flow.py:424` handles the width change unmodified.

## Default is off

`marginalize=None` is the default and every code path short-circuits on an empty index set, so this is a no-op for existing configs.

## Commits

1. **`Product: add 'marginalize' role`** — cherry-pick of `9c91d11`. Handles all six paths that partition the parameter vector: `forward` (the `param_dim == 0` shortcut, the direct standard-normal branch, and the CDF fallback), `inverse` (both branches), and `simulate_batch`. Invalid indices and `marginalize` on a `"fixed"` param both raise at construction, so a typo fails at launch rather than silently.

2. **`Product: keep simulate_batch's RNG stream unchanged`** — deviation from upstream, please review. The original commit rewrote `simulate_batch` to draw one `torch.rand(batch_size)` per parameter, because the single batched draw was sized by `_param_dim`, which no longer covers marginalized params. Statistically equivalent, but it consumes the RNG differently, so seeded runs stopped reproducing bit-for-bit **even with `marginalize` unused**. This restores the batched draw and sizes it by the number of *sampled* params (free + marginalized = all non-fixed). With no marginalize that equals `_param_dim` exactly, so the loop body and the RNG stream are identical to `main`. Net effect: the `simulate_batch` diff against `main` is now two lines.

3. **`Product: document the marginalize role in the class docstring`** — the class docstring listed `"fixed"` and demonstrated it in the worked example, so the feature was discoverable only by reading `__init__`.

## One thing worth knowing

`forward()` cannot recover a marginalized value from the latent vector, so **the marginalized columns of generated posterior samples are prior draws, not posterior draws**. Corner-plotting raw `samples/posterior/*.npz` will show the prior in those panels. That is correct for a marginalization, but reads like a bug if unexpected, so it is now called out in the docstring.

The importance weights are unaffected: the proposal factorizes as `q(free) · p(marginalized)` against a prior of `p(free) · p(marginalized)`, so the nuisance factor cancels exactly.

## Testing

Not run — `import torch` fails in my environment (`libcudnn.so.9: cannot open shared object file`), which breaks `pytest tests` collection on `main` as well, so it is not introduced here. Verification is static review of every partition path plus `py_compile`.

Worth adding a unit test for this before or shortly after merge — `product.py` currently has no direct coverage, and the natural assertions are cheap and CPU-only: latent dim shrinks by `len(marginalize)`, output width is unchanged, `inverse(forward(z))` round-trips on the free coordinates, and `simulate_batch` output is unchanged bit-for-bit under a fixed seed when `marginalize` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)